### PR TITLE
Introduce YearFactory for cached/memoized Year instances and wire into codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ npm run test -- --coverage
 
 The library is the primary artifact. Key pieces:
 
+- **`BaseYear.js` / `BaseWeek.js`** — Shared runtime contracts for year and week calculators.
 - **`Year.js` / `Week.js` / `CalendarBuilder.js`** — One-year calendar calculations and month grid generation.
 - **`YearFactory.js`** — Memoized factory/cache for `Year`-like calculators. `Week` and `Series` use this to avoid recomputing anchor dates.
 - **`lib/3year/Year.js` / `lib/3year/Week.js` / `lib/3year/Series.js` / `ProperSundays.js`** — Three-year logic: Advent-based Series A/B/C, the Transfiguration-before-Lent rule, and Proper 3-29 mapping for Ordinary Time.
@@ -126,3 +127,12 @@ When adding or changing any color, background, border, or outline:
 - The one-year lectionary uses the historic 57-week cycle. The three-year lectionary uses Series A/B/C, removes the pre-Lent Gesima season, and maps post-Pentecost Sundays to Proper 3-29 (`58`-`84`).
 - Propers can be week-based or fixed-date. Two dates in the same liturgical week share movable propers; festivals and commemorations can also match directly by month/day.
 - Liturgical color is stored as a proper entry (type 25) alongside readings.
+
+## Caching Notes
+
+- Keep caching **outside** `Year` and `ThreeYear`. The year implementations should stay focused on liturgical business logic.
+- `YearFactory` only memoizes the prescribed **`BaseYear` zero-argument API**. If a method is not on `BaseYear`, it is intentionally not cached.
+- `BaseYear` methods are expected to be **pure** and **zero-argument**. If that changes, revisit `YearFactory`.
+- `ThreeYear` participates through inheritance (`ThreeYear -> Year -> BaseYear`). Do not build a separate 3-year cache path.
+- Cached Luxon `DateTime`s are rehydrated from plain object data instead of stored raw so ambient Luxon settings like zone do not leak between callers.
+- Prefer small, explicit cache rules over generalized cache frameworks unless the rest of the repo actually needs broader abstraction.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,11 @@ Coverage report:
 npm run test -- --coverage
 ```
 
+## Code Quality
+
+- Prefer JSDoc for public APIs, shared library helpers, and non-trivial internal functions so the JavaScript code remains easier to understand and safer to refactor.
+- Add useful explanatory comments when the logic is domain-specific, subtle, or performance-motivated. Avoid comments that only restate the code literally.
+
 ## Architecture
 
 ### Core Library (`/lib`)

--- a/app/Calendar.jsx
+++ b/app/Calendar.jsx
@@ -109,8 +109,10 @@ function CalendarDay({ day, selectedDay, onSelectDay }) {
     festivals: day.propers.festivals,
   });
   const color =
-    findColor(...displayPropers, day.sunday?.propers.lectionary)?.toLowerCase() ??
-    "none";
+    findColor(
+      ...displayPropers,
+      day.sunday?.propers.lectionary
+    )?.toLowerCase() ?? "none";
   const className = getDayClassName({ color, isToday, isSelected });
   const isSunday = day.date.weekday === 7;
   const dayNumberClassName = getDayNumberClassName({
@@ -149,15 +151,9 @@ function CalendarDay({ day, selectedDay, onSelectDay }) {
             return (
               <div key={id}>
                 <h4>{summary[0]?.text}</h4>
-                {summary[19]?.text && (
-                  <div>Old Test: {summary[19].text}</div>
-                )}
-                {summary[1]?.text && (
-                  <div>Epistle: {summary[1].text}</div>
-                )}
-                {summary[2]?.text && (
-                  <div>Gospel: {summary[2].text}</div>
-                )}
+                {summary[19]?.text && <div>Old Test: {summary[19].text}</div>}
+                {summary[1]?.text && <div>Epistle: {summary[1].text}</div>}
+                {summary[2]?.text && <div>Gospel: {summary[2].text}</div>}
                 <br />
               </div>
             );

--- a/lib/3year/KeyLoader.js
+++ b/lib/3year/KeyLoader.js
@@ -17,27 +17,41 @@ import { ThreeYearWeek } from "./Week.js";
  * });
  */
 export class ThreeYearKeyLoader {
+  /** @type {import("../Loader.js").SeriesDatasetMap} */
+  #series;
+
+  /** @type {import("../Loader.js").ProperDatasetMap} */
+  #shared;
+
   /**
-   * @param {{ series: { A: object[], B: object[], C: object[] }, [key: string]: object[] }} data
+   * @param {{
+   *   series: import("../Loader.js").SeriesDatasetMap,
+   *   [key: string]: import("../Loader.js").ProperDatasetMap[string] | import("../Loader.js").SeriesDatasetMap,
+   * }} data
    *   `series` maps liturgical series letters to their proper datasets.
    *   All other keys are shared datasets applied regardless of series.
    */
   constructor({ series, ...shared }) {
-    this._series = series;
-    this._shared = shared;
+    this.#series = series;
+    this.#shared = shared;
   }
 
   /**
    * Load propers for a given date.
    * The week number is computed internally via ThreeYearWeek so ordinary-time
    * Propers (weeks 58–84) resolve correctly regardless of what the caller passes.
-   * @param {DateTime} date
+   * @param {import("luxon").DateTime} date
+   * @returns {import("../Loader.js").ProperDatasetMap}
    */
   load(date) {
     const weekOfLectionary = new ThreeYearWeek(date).getWeek();
     // Luxon represents Sunday as weekday 7; normalize to 0
     const weekday = date.weekday === 7 ? 0 : date.weekday;
 
+    /**
+     * @param {import("../Loader.js").Proper[]} entries
+     * @returns {import("../Loader.js").Proper[]}
+     */
     const filter = (entries) =>
       entries
         .filter(
@@ -52,10 +66,11 @@ export class ThreeYearKeyLoader {
         });
 
     const seriesKey = new Series(date.toJSDate()).getSeries();
-    const lectionary = this._series[seriesKey] ?? [];
+    const lectionary = this.#series[seriesKey] ?? [];
 
+    /** @type {import("../Loader.js").ProperDatasetMap} */
     const result = { lectionary: filter(lectionary) };
-    for (const [key, value] of Object.entries(this._shared)) {
+    for (const [key, value] of Object.entries(this.#shared)) {
       result[key] = filter(value);
     }
     return result;

--- a/lib/3year/Series.js
+++ b/lib/3year/Series.js
@@ -4,11 +4,17 @@ import { Year } from "../Year.js";
 import { YearFactory } from "../YearFactory.js";
 
 export class Series {
+  /** @type {import("luxon").DateTime} */
+  #date;
+
+  /**
+   * @param {Date | import("luxon").DateTime} date
+   */
   constructor(date) {
     if (!(date instanceof DateTime)) {
       date = DateTime.fromJSDate(date);
     }
-    this._date = date.startOf("day");
+    this.#date = date.startOf("day");
   }
 
   /**
@@ -21,9 +27,9 @@ export class Series {
    * @returns {"A"|"B"|"C"}
    */
   getSeries() {
-    const advent = YearFactory.get(this._date.year, Year).getAdvent();
+    const advent = YearFactory.get(this.#date.year, Year).getAdvent();
     const adventYear =
-      this._date >= advent ? this._date.year : this._date.year - 1;
+      this.#date >= advent ? this.#date.year : this.#date.year - 1;
     return ["A", "B", "C"][adventYear % 3];
   }
 }

--- a/lib/3year/Series.js
+++ b/lib/3year/Series.js
@@ -20,7 +20,7 @@ export class Series {
    * @returns {"A"|"B"|"C"}
    */
   getSeries() {
-    const advent = new Year(this._date.year).getAdvent();
+    const advent = Year.get(this._date.year).getAdvent();
     const adventYear =
       this._date >= advent ? this._date.year : this._date.year - 1;
     return ["A", "B", "C"][adventYear % 3];

--- a/lib/3year/Series.js
+++ b/lib/3year/Series.js
@@ -1,5 +1,6 @@
 import { DateTime } from "luxon";
 
+import { YearFactory } from "../YearFactory.js";
 import { Year } from "../Year.js";
 
 export class Series {
@@ -20,7 +21,7 @@ export class Series {
    * @returns {"A"|"B"|"C"}
    */
   getSeries() {
-    const advent = Year.get(this._date.year).getAdvent();
+    const advent = YearFactory.get(this._date.year, Year).getAdvent();
     const adventYear =
       this._date >= advent ? this._date.year : this._date.year - 1;
     return ["A", "B", "C"][adventYear % 3];

--- a/lib/3year/Series.js
+++ b/lib/3year/Series.js
@@ -1,7 +1,7 @@
 import { DateTime } from "luxon";
 
-import { YearFactory } from "../YearFactory.js";
 import { Year } from "../Year.js";
+import { YearFactory } from "../YearFactory.js";
 
 export class Series {
   constructor(date) {

--- a/lib/3year/Week.js
+++ b/lib/3year/Week.js
@@ -3,11 +3,7 @@ import { Week } from "../Week.js";
 import { ThreeYear } from "./Year.js";
 
 export class ThreeYearWeek extends Week {
-  constructor(date) {
-    super(date);
-    // Replace the Year instance with a ThreeYear so getTransfiguration() is correct
-    this._year = new ThreeYear(this._date);
-  }
+  static CalculatorType = ThreeYear;
 
   getWeek() {
     const year = this._year;

--- a/lib/3year/Week.js
+++ b/lib/3year/Week.js
@@ -1,12 +1,40 @@
+import { DateTime } from "luxon";
+
 import ProperSundays from "../ProperSundays.js";
-import { Week } from "../Week.js";
+import { getSunday, getWeekDifference } from "../weekHelpers.js";
+import { YearFactory } from "../YearFactory.js";
 import { ThreeYear } from "./Year.js";
 
-export class ThreeYearWeek extends Week {
-  static CalculatorType = ThreeYear;
+/** @implements {import("../BaseWeek.js").BaseWeek} */
+export class ThreeYearWeek {
+  /** @type {import("luxon").DateTime} */
+  #date;
+
+  /** @type {ThreeYear} */
+  #year;
+
+  /**
+   * @param {Date | import("luxon").DateTime} date
+   */
+  constructor(date) {
+    if (!(date instanceof DateTime)) {
+      date = DateTime.fromJSDate(date);
+    }
+
+    this.#date = date.startOf("day");
+    this.#year = YearFactory.get(this.#date, ThreeYear);
+  }
+
+  /**
+   * Find the Sunday closest to the date we're calculating off. If that day is a Sunday, it just returns that date.
+   * @returns {DateTime}
+   */
+  getSunday() {
+    return getSunday(this.#date);
+  }
 
   getWeek() {
-    const year = this._year;
+    const year = this.#year;
     const advent = year.getAdvent();
     const epiphany = year.getEpiphany();
     const epiphanySunday = year.getEpiphanySunday();
@@ -24,12 +52,12 @@ export class ThreeYearWeek extends Week {
 
     // Advent and beyond (into the next liturgical year)
     if (sunday >= advent) {
-      return 1 + this.getWeekDifference(advent, sunday);
+      return 1 + getWeekDifference(advent, sunday);
     }
 
     // Before Epiphany (Sunday after Christmas, etc.)
     if (sunday < epiphany) {
-      return 6 - this.getWeekDifference(sunday, epiphanySunday);
+      return 6 - getWeekDifference(sunday, epiphanySunday);
     }
 
     // Epiphany season through Transfiguration Sunday
@@ -37,7 +65,7 @@ export class ThreeYearWeek extends Week {
       if (sunday.valueOf() === transfiguration.valueOf()) {
         return 12;
       }
-      const n = this.getWeekDifference(epiphanySunday, sunday);
+      const n = getWeekDifference(epiphanySunday, sunday);
       // n <= 5: Baptism of Our Lord (7) through Epiphany 5 (11)
       // n > 5: Epiphany 6 (13), Epiphany 7 (14), Epiphany 8 (15)
       return n <= 5 ? 6 + n : 7 + n;
@@ -45,7 +73,7 @@ export class ThreeYearWeek extends Week {
 
     // Lent through Trinity Sunday (weeks 16–30)
     if (sunday > transfiguration && sunday <= trinitySunday) {
-      return 16 + this.getWeekDifference(lent, sunday);
+      return 16 + getWeekDifference(lent, sunday);
     }
 
     // Ordinary Time — ProperSundays calendar-date lookup.

--- a/lib/BaseWeek.js
+++ b/lib/BaseWeek.js
@@ -1,0 +1,25 @@
+/**
+ * Shared interface for week calculators.
+ *
+ * Implementations normalize a specific calendar date, expose the Sunday that
+ * anchors that date's liturgical week, and compute the corresponding week
+ * number for their lectionary system.
+ *
+ * @interface
+ */
+export class BaseWeek {
+  /**
+   * Return the Sunday that anchors the current date's liturgical week.
+   *
+   * @returns {import("luxon").DateTime}
+   */
+  getSunday() {}
+
+  /**
+   * Return the liturgical week number for the current date, or `null` when the
+   * date requires special caller handling.
+   *
+   * @returns {number | null}
+   */
+  getWeek() {}
+}

--- a/lib/BaseYear.js
+++ b/lib/BaseYear.js
@@ -1,0 +1,107 @@
+/**
+ * Shared interface for liturgical year calculators.
+ *
+ * Implementations calculate the canonical anchor dates used throughout the
+ * church year. `YearFactory` only memoizes this prescribed API, which keeps the
+ * cache layer simple and leaves subclass-specific helper methods uncached.
+ *
+ * Subclasses are expected to implement every method below. The default methods
+ * throw so incomplete implementations fail fast.
+ *
+ * @interface
+ */
+export class BaseYear {
+  /**
+   * @param {string} methodName
+   * @returns {never}
+   */
+  _notImplemented(methodName) {
+    throw new Error(
+      `${this.constructor.name}.${methodName}() must be implemented`
+    );
+  }
+
+  /**
+   * @returns {import("luxon").DateTime}
+   */
+  getAdvent() {
+    return this._notImplemented("getAdvent");
+  }
+
+  /**
+   * @returns {import("luxon").DateTime}
+   */
+  getChristmas() {
+    return this._notImplemented("getChristmas");
+  }
+
+  /**
+   * @returns {import("luxon").DateTime}
+   */
+  getEpiphany() {
+    return this._notImplemented("getEpiphany");
+  }
+
+  /**
+   * @returns {import("luxon").DateTime}
+   */
+  getEpiphanySunday() {
+    return this._notImplemented("getEpiphanySunday");
+  }
+
+  /**
+   * @returns {import("luxon").DateTime}
+   */
+  getTransfiguration() {
+    return this._notImplemented("getTransfiguration");
+  }
+
+  /**
+   * @returns {import("luxon").DateTime}
+   */
+  getAshWednesday() {
+    return this._notImplemented("getAshWednesday");
+  }
+
+  /**
+   * @returns {import("luxon").DateTime}
+   */
+  getLent() {
+    return this._notImplemented("getLent");
+  }
+
+  /**
+   * @returns {import("luxon").DateTime}
+   */
+  getEaster() {
+    return this._notImplemented("getEaster");
+  }
+
+  /**
+   * @returns {import("luxon").DateTime}
+   */
+  getTrinity() {
+    return this._notImplemented("getTrinity");
+  }
+
+  /**
+   * @returns {import("luxon").DateTime}
+   */
+  getPentecost() {
+    return this._notImplemented("getPentecost");
+  }
+
+  /**
+   * @returns {import("luxon").DateTime}
+   */
+  getLastSunday() {
+    return this._notImplemented("getLastSunday");
+  }
+
+  /**
+   * @returns {import("luxon").DateTime}
+   */
+  getEndOfYear() {
+    return this._notImplemented("getEndOfYear");
+  }
+}

--- a/lib/CalendarBuilder.js
+++ b/lib/CalendarBuilder.js
@@ -6,31 +6,37 @@ import { Week } from "./Week.js";
  * Build a calendar grid for a given month.
  */
 export class CalendarBuilder {
+  /** @type {number} */
+  #year;
+
+  /** @type {number} */
+  #month;
+
   /**
-   * @param {int} year
-   * @param {int} month
+   * @param {number} year
+   * @param {number} month
    */
   constructor(year, month) {
-    /**
-     * @type {int}
-     * @private
-     */
-    this._year = year;
-    /**
-     * @type {int}
-     * @private
-     */
-    this._month = month;
+    this.#year = year;
+    this.#month = month;
   }
 
   /**
-   * @param {Loader} loader
+   * @template TPropers
+   * @param {{ load(date: import("luxon").DateTime, weekOfLectionary: number | null): TPropers }} loader
+   * @returns {Array<Array<{
+   *   date: import("luxon").DateTime,
+   *   day: number,
+   *   week: number | null,
+   *   propers: TPropers,
+   *   sunday: object | null,
+   * } | null>>}
    */
   build(loader) {
-    const first = DateTime.local(this._year, this._month, 1, 0, 0, 0);
+    const first = DateTime.local(this.#year, this.#month, 1, 0, 0, 0);
     const last = DateTime.local(
-      this._year,
-      this._month,
+      this.#year,
+      this.#month,
       first.daysInMonth,
       0,
       0,
@@ -44,6 +50,13 @@ export class CalendarBuilder {
       current = current.minus({ days: first.weekday });
     }
 
+    /** @type {Array<Array<{
+     *   date: import("luxon").DateTime,
+     *   day: number,
+     *   week: number | null,
+     *   propers: TPropers,
+     *   sunday: object | null,
+     * } | null>>} */
     const grid = [];
 
     let row = 0;

--- a/lib/KeyLoader.js
+++ b/lib/KeyLoader.js
@@ -4,21 +4,26 @@ import { matchesProperDate } from "./matchesProperDate.js";
  * @implements Loader
  */
 export class KeyLoader {
+  /** @type {import("./Loader.js").ProperDatasetMap} */
+  #data;
+
+  /**
+   * @param {import("./Loader.js").ProperDatasetMap} data
+   */
   constructor(data) {
-    /**
-     * @private
-     */
-    this._data = data;
+    this.#data = data;
   }
 
   /**
    * Load specific propers
-   * @param {DateTime} date
-   * @param {number} weekOfLectionary
+   * @param {import("luxon").DateTime} date
+   * @param {number | null} weekOfLectionary
+   * @returns {import("./Loader.js").ProperDatasetMap}
    */
   load(date, weekOfLectionary) {
+    /** @type {import("./Loader.js").ProperDatasetMap} */
     const data = {};
-    for (const [key, value] of Object.entries(this._data)) {
+    for (const [key, value] of Object.entries(this.#data)) {
       data[key] = value
         .filter((proper) => matchesProperDate(proper, date, weekOfLectionary))
         .sort((first, second) => {

--- a/lib/Loader.js
+++ b/lib/Loader.js
@@ -1,11 +1,43 @@
 /**
+ * A single lectionary/festival/daily proper entry.
+ * `week` + `day` identify movable propers, while `month` + `day` identify
+ * fixed-date observances.
+ *
+ * @typedef {{
+ *   type: number,
+ *   text: string,
+ *   week?: number | null,
+ *   month?: number | null,
+ *   day?: number | null,
+ * }} Proper
+ */
+
+/**
+ * Mapping of dataset keys such as `lectionary`, `festivals`, or `daily` to
+ * their filtered proper arrays.
+ *
+ * @typedef {Record<string, Proper[]>} ProperDatasetMap
+ */
+
+/**
+ * Liturgical series key used by the three-year lectionary.
+ * @typedef {"A" | "B" | "C"} SeriesKey
+ */
+
+/**
+ * Per-series three-year lectionary data.
+ * @typedef {Record<SeriesKey, Proper[]>} SeriesDatasetMap
+ */
+
+/**
  * @interface
  */
 export default class Loader {
   /**
    * Load specific propers
-   * @param {DateTime} date
-   * @param {number} weekOfLectionary
+   * @param {import("luxon").DateTime} date
+   * @param {number | null} weekOfLectionary
+   * @returns {Proper[] | ProperDatasetMap}
    */
   load(date, weekOfLectionary) {}
 }

--- a/lib/SimpleLoader.js
+++ b/lib/SimpleLoader.js
@@ -4,20 +4,24 @@ import { matchesProperDate } from "./matchesProperDate.js";
  * @implements Loader
  */
 export class SimpleLoader {
+  /** @type {import("./Loader.js").Proper[]} */
+  #data;
+
+  /**
+   * @param {...import("./Loader.js").Proper[]} dataSets
+   */
   constructor(...dataSets) {
-    /**
-     * @private
-     */
-    this._data = dataSets.flat();
+    this.#data = dataSets.flat();
   }
 
   /**
    * Load specific propers
-   * @param {DateTime} date
-   * @param {number} weekOfLectionary
+   * @param {import("luxon").DateTime} date
+   * @param {number | null} weekOfLectionary
+   * @returns {import("./Loader.js").Proper[]}
    */
   load(date, weekOfLectionary) {
-    return this._data.filter((proper) =>
+    return this.#data.filter((proper) =>
       matchesProperDate(proper, date, weekOfLectionary)
     );
   }

--- a/lib/Week.js
+++ b/lib/Week.js
@@ -1,7 +1,7 @@
 import { DateTime } from "luxon";
 
-import { YearFactory } from "./YearFactory.js";
 import { Year } from "./Year.js";
+import { YearFactory } from "./YearFactory.js";
 export class Week {
   constructor(date) {
     // If we're not receiving a luxon DateTime, assume a JSDate and convert

--- a/lib/Week.js
+++ b/lib/Week.js
@@ -2,7 +2,10 @@ import { DateTime } from "luxon";
 
 import { Year } from "./Year.js";
 import { YearFactory } from "./YearFactory.js";
+
 export class Week {
+  static CalculatorType = Year;
+
   constructor(date) {
     // If we're not receiving a luxon DateTime, assume a JSDate and convert
     if (!(date instanceof DateTime)) {
@@ -18,7 +21,7 @@ export class Week {
      * @type {Year}
      * @private
      */
-    this._year = YearFactory.get(this._date, Year);
+    this._year = YearFactory.get(this._date, this.constructor.CalculatorType);
   }
 
   /**

--- a/lib/Week.js
+++ b/lib/Week.js
@@ -17,7 +17,7 @@ export class Week {
      * @type {Year}
      * @private
      */
-    this._year = new Year(this._date);
+    this._year = Year.get(this._date);
   }
 
   /**

--- a/lib/Week.js
+++ b/lib/Week.js
@@ -1,5 +1,6 @@
 import { DateTime } from "luxon";
 
+import { YearFactory } from "./YearFactory.js";
 import { Year } from "./Year.js";
 export class Week {
   constructor(date) {
@@ -17,7 +18,7 @@ export class Week {
      * @type {Year}
      * @private
      */
-    this._year = Year.get(this._date);
+    this._year = YearFactory.get(this._date, Year);
   }
 
   /**

--- a/lib/Week.js
+++ b/lib/Week.js
@@ -1,10 +1,15 @@
 import { DateTime } from "luxon";
-
+import { getSunday, getWeekDifference } from "./weekHelpers.js";
 import { Year } from "./Year.js";
 import { YearFactory } from "./YearFactory.js";
 
+/** @implements {import("./BaseWeek.js").BaseWeek} */
 export class Week {
-  static CalculatorType = Year;
+  /** @type {import("luxon").DateTime} */
+  #date;
+
+  /** @type {Year} */
+  #year;
 
   constructor(date) {
     // If we're not receiving a luxon DateTime, assume a JSDate and convert
@@ -12,16 +17,8 @@ export class Week {
       date = DateTime.fromJSDate(date);
     }
 
-    /**
-     * @type {DateTime}
-     * @private
-     */
-    this._date = date.startOf("day");
-    /**
-     * @type {Year}
-     * @private
-     */
-    this._year = YearFactory.get(this._date, this.constructor.CalculatorType);
+    this.#date = date.startOf("day");
+    this.#year = YearFactory.get(this.#date, Year);
   }
 
   /**
@@ -29,29 +26,16 @@ export class Week {
    * @returns {DateTime}
    */
   getSunday() {
-    return this._date.weekday === 7
-      ? this._date
-      : this._date.minus({ days: this._date.weekday });
-  }
-
-  /**
-   * Find the difference between two weeks.
-   * @param {DateTime} week1
-   * @param {DateTime} week2
-   * @private
-   */
-  getWeekDifference(week1, week2) {
-    const { weeks } = week2.diff(week1, ["weeks"]).toObject();
-    return weeks;
+    return getSunday(this.#date);
   }
 
   getWeek() {
-    const advent = this._year.getAdvent();
-    const epiphany = this._year.getEpiphany();
-    const epiphanySunday = this._year.getEpiphanySunday();
-    const transfiguration = this._year.getTransfiguration();
-    const endOfYear = this._year.getEndOfYear();
-    const lastSunday = this._year.getLastSunday();
+    const advent = this.#year.getAdvent();
+    const epiphany = this.#year.getEpiphany();
+    const epiphanySunday = this.#year.getEpiphanySunday();
+    const transfiguration = this.#year.getTransfiguration();
+    const endOfYear = this.#year.getEndOfYear();
+    const lastSunday = this.#year.getLastSunday();
     const sunday = this.getSunday();
 
     // If Christmas is a Sunday you need to handle this yourself
@@ -59,19 +43,19 @@ export class Week {
       return null;
     } else if (sunday >= advent) {
       // After Advent
-      return 1 + this.getWeekDifference(advent, sunday);
+      return 1 + getWeekDifference(advent, sunday);
     } else if (sunday >= epiphany && sunday < transfiguration) {
       // After Epiphany, Before Transfiguration
-      return 6 + this.getWeekDifference(epiphanySunday, sunday);
+      return 6 + getWeekDifference(epiphanySunday, sunday);
     } else if (sunday < epiphany) {
       // Before Epiphany
-      return 6 - this.getWeekDifference(sunday, epiphanySunday);
+      return 6 - getWeekDifference(sunday, epiphanySunday);
     } else if (sunday >= transfiguration && sunday <= endOfYear) {
       // After Transfiguration and before the end of the year (Pentecost)
-      return 12 + this.getWeekDifference(transfiguration, sunday);
+      return 12 + getWeekDifference(transfiguration, sunday);
     } else {
       // The end of the Church Year to Last Sunday (eq. Third Last)
-      return 57 - this.getWeekDifference(sunday, lastSunday);
+      return 57 - getWeekDifference(sunday, lastSunday);
     }
   }
 }

--- a/lib/Year.js
+++ b/lib/Year.js
@@ -1,9 +1,19 @@
 import { DateTime } from "luxon";
+import { YearFactory } from "./YearFactory.js";
 
 /**
  * Calculates important liturgical days for a given calendar year.
  */
 export class Year {
+  /**
+   * Factory helper for constructing Year instances.
+   * @param {int} year Year to calculate dates for.
+   * @returns {Year}
+   */
+  static get(year) {
+    return YearFactory.get(year, this);
+  }
+
   /**
    * Calculates important liturgical days for a given calendar year.
    * @param {int} year Year to calculate dates for.

--- a/lib/Year.js
+++ b/lib/Year.js
@@ -1,19 +1,9 @@
 import { DateTime } from "luxon";
-import { YearFactory } from "./YearFactory.js";
 
 /**
  * Calculates important liturgical days for a given calendar year.
  */
 export class Year {
-  /**
-   * Factory helper for constructing Year instances.
-   * @param {int} year Year to calculate dates for.
-   * @returns {Year}
-   */
-  static get(year) {
-    return YearFactory.get(year, this);
-  }
-
   /**
    * Calculates important liturgical days for a given calendar year.
    * @param {int} year Year to calculate dates for.

--- a/lib/Year.js
+++ b/lib/Year.js
@@ -1,9 +1,10 @@
 import { DateTime } from "luxon";
+import { BaseYear } from "./BaseYear.js";
 
 /**
  * Calculates important liturgical days for a given calendar year.
  */
-export class Year {
+export class Year extends BaseYear {
   #year;
 
   /**
@@ -11,6 +12,7 @@ export class Year {
    * @param {int} year Year to calculate dates for.
    */
   constructor(year) {
+    super();
     this.#year = parseInt(year, 10);
   }
 

--- a/lib/Year.js
+++ b/lib/Year.js
@@ -4,12 +4,14 @@ import { DateTime } from "luxon";
  * Calculates important liturgical days for a given calendar year.
  */
 export class Year {
+  #year;
+
   /**
    * Calculates important liturgical days for a given calendar year.
    * @param {int} year Year to calculate dates for.
    */
   constructor(year) {
-    this.year = parseInt(year, 10);
+    this.#year = parseInt(year, 10);
   }
 
   getAdvent() {
@@ -20,11 +22,11 @@ export class Year {
   }
 
   getChristmas() {
-    return DateTime.local(this.year, 12, 25, 0, 0, 0);
+    return DateTime.local(this.#year, 12, 25, 0, 0, 0);
   }
 
   getEpiphany() {
-    return DateTime.local(this.year, 1, 6, 0, 0, 0);
+    return DateTime.local(this.#year, 1, 6, 0, 0, 0);
   }
 
   getEpiphanySunday() {
@@ -53,7 +55,7 @@ export class Year {
   }
 
   getEaster() {
-    const year = this.year;
+    const year = this.#year;
 
     const a = year % 19;
     const b = Math.floor(year / 100);

--- a/lib/YearFactory.js
+++ b/lib/YearFactory.js
@@ -1,4 +1,5 @@
 import { DateTime } from "luxon";
+import { BaseYear } from "./BaseYear.js";
 
 /**
  * Object shape accepted by the factory when the caller passes a Luxon-style
@@ -14,79 +15,26 @@ import { DateTime } from "luxon";
 /**
  * Constructor shape for Year-like calculators.
  * @template T
- * @typedef {new (value: unknown) => T} YearType
+ * @typedef {new (year: number) => T} YearType
  */
 
-/**
- * Nested argument-keyed memoization tree used per instance and per method.
- * @typedef {Map<unknown, MemoNode | unknown>} MemoNode
- */
-
-/**
- * Configuration hooks for a cached calculator type.
- *
- * `getInstanceKey` determines when two inputs should share one cached instance.
- * `getConstructorArg` transforms the incoming value before constructing the
- * calculator. The defaults preserve the current Gregorian year-based behavior.
- *
- * @typedef {{
- *   getInstanceKey?: (value: YearLikeValue) => string | number,
- *   getConstructorArg?: (value: YearLikeValue) => unknown,
- * }} YearFactoryTypeConfig
- */
-
-/**
- * Adapter for freezing and thawing cacheable method return values.
- *
- * @typedef {{
- *   test: (value: unknown) => boolean,
- *   freeze: (value: unknown) => unknown,
- *   thaw: (value: unknown) => unknown,
- * }} ResultAdapter
- */
+/** @typedef {{ kind: "raw", value: unknown } | { kind: "datetime", value: ReturnType<DateTime["toObject"]> }} CachedResult */
 
 // Shared instances keyed first by calculator class, then by calendar year.
 // Example: cache.get(Year).get(2025) -> cached Year-like instance for 2025.
-/** @type {Map<YearType<object>, Map<string | number, object>>} */
+/** @type {Map<YearType<object>, Map<number, object>>} */
 const cache = new Map();
 // Each source class gets exactly one generated memoizing subclass.
 /** @type {WeakMap<YearType<object>, YearType<object>>} */
 const cachedTypes = new WeakMap();
-/** @type {WeakMap<YearType<object>, YearFactoryTypeConfig>} */
-const typeConfigs = new WeakMap();
-/** @type {ResultAdapter[]} */
-const resultAdapters = [];
-const CACHED_VALUE = Symbol("cachedValue");
 const METHOD_CACHE = Symbol("methodCache");
 const UNCACHEABLE = Symbol("uncacheable");
-
-/**
- * @param {YearLikeValue} value
- * @returns {string | number}
- */
-function defaultGetInstanceKey(value) {
-  return YearFactory.getYear(value);
-}
-
-/**
- * @param {YearLikeValue} value
- * @returns {unknown}
- */
-function defaultGetConstructorArg(value) {
-  return YearFactory.getYear(value);
-}
-
-/**
- * @param {YearType<object>} Type
- * @returns {Required<YearFactoryTypeConfig>}
- */
-function getTypeConfig(Type) {
-  const config = typeConfigs.get(Type);
-  return {
-    getInstanceKey: config?.getInstanceKey ?? defaultGetInstanceKey,
-    getConstructorArg: config?.getConstructorArg ?? defaultGetConstructorArg,
-  };
-}
+// Memoization intentionally covers only the canonical BaseYear API. These
+// methods are expected to be pure and zero-argument; helper methods with
+// parameters stay outside the cache layer on purpose.
+const MEMOIZED_METHODS = Object.getOwnPropertyNames(BaseYear.prototype).filter(
+  (name) => name !== "constructor" && !name.startsWith("_")
+);
 
 /**
  * @param {unknown} value
@@ -102,97 +50,50 @@ function isPrimitive(value) {
 
 /**
  * @param {unknown} value
- * @returns {{ kind: "raw", value: unknown } | { kind: "adapted", adapter: ResultAdapter, value: unknown } | typeof UNCACHEABLE}
+ * @returns {CachedResult | typeof UNCACHEABLE}
  */
 function freezeResult(value) {
-  if (isPrimitive(value)) {
-    return { kind: "raw", value };
+  if (DateTime.isDateTime(value)) {
+    return {
+      kind: "datetime",
+      value: value.toObject(),
+    };
   }
 
-  for (const adapter of resultAdapters) {
-    if (adapter.test(value)) {
-      return {
-        kind: "adapted",
-        adapter,
-        value: adapter.freeze(value),
-      };
-    }
+  if (isPrimitive(value)) {
+    return { kind: "raw", value };
   }
 
   return UNCACHEABLE;
 }
 
 /**
- * @param {{ kind: "raw", value: unknown } | { kind: "adapted", adapter: ResultAdapter, value: unknown }} entry
+ * @param {CachedResult} entry
  * @returns {unknown}
  */
 function thawResult(entry) {
-  if (entry.kind === "raw") {
-    return entry.value;
+  if (entry.kind === "datetime") {
+    return DateTime.fromObject(entry.value);
   }
 
-  return entry.adapter.thaw(entry.value);
+  return entry.value;
 }
 
 /**
- * Collect all callable method names from a Year-like class and its prototypes.
- *
- * @param {YearType<object>} Type
- * @returns {string[]}
- */
-function getMethodNames(Type) {
-  // Walk the prototype chain so subclasses inherit wrapped versions of both
-  // their own methods and Year methods.
-  const names = new Set();
-  let prototype = Type.prototype;
-
-  while (prototype && prototype !== Object.prototype) {
-    for (const [name, descriptor] of Object.entries(
-      Object.getOwnPropertyDescriptors(prototype)
-    )) {
-      if (name === "constructor" || typeof descriptor.value !== "function") {
-        continue;
-      }
-
-      names.add(name);
-    }
-
-    prototype = Object.getPrototypeOf(prototype);
-  }
-
-  return [...names];
-}
-
-/**
- * Resolve a memoized result for one method invocation on one cached instance.
+ * Resolve a memoized result for one prescribed BaseYear method on one cached
+ * instance. Callers must only use this for pure, zero-argument methods.
  *
  * @template T
- * @param {object & { [METHOD_CACHE]: Map<string, MemoNode> }} instance
+ * @param {object & { [METHOD_CACHE]: Map<string, CachedResult> }} instance
  * @param {string} methodName
- * @param {unknown[]} args
  * @param {() => T} invoke
  * @returns {T}
  */
-function memoizeCall(instance, methodName, args, invoke) {
-  // Cache entries are stored as a nested Map tree keyed by argument identity.
-  // That lets us distinguish values such as `undefined`, symbols, objects, and
-  // numbers without depending on fragile JSON serialization.
+function memoizeCall(instance, methodName, invoke) {
   const methodCache = instance[METHOD_CACHE];
 
-  if (!methodCache.has(methodName)) {
-    methodCache.set(methodName, new Map());
-  }
-
-  let node = methodCache.get(methodName);
-  for (const arg of args) {
-    if (!node.has(arg)) {
-      node.set(arg, new Map());
-    }
-    node = node.get(arg);
-  }
-
-  if (node.has(CACHED_VALUE)) {
-    return thawResult(node.get(CACHED_VALUE));
+  if (methodCache.has(methodName)) {
+    return thawResult(methodCache.get(methodName));
   }
 
   const result = invoke();
@@ -202,7 +103,7 @@ function memoizeCall(instance, methodName, args, invoke) {
     return result;
   }
 
-  node.set(CACHED_VALUE, frozen);
+  methodCache.set(methodName, frozen);
   return thawResult(frozen);
 }
 
@@ -232,15 +133,18 @@ function createCachedType(Type) {
     }
   }
 
-  for (const methodName of getMethodNames(Type)) {
+  // Only memoize the canonical BaseYear API. Subclass-specific helper methods
+  // and any parameterized behavior stay untouched so the cache layer remains
+  // small and easy to reason about.
+  for (const methodName of MEMOIZED_METHODS) {
     Object.defineProperty(CachedType.prototype, methodName, {
       configurable: true,
       writable: true,
-      value(...args) {
+      value() {
         // Resolve the original method from the source prototype, then memoize
-        // the result on this cached instance for this exact argument list.
-        return memoizeCall(this, methodName, args, () =>
-          Type.prototype[methodName].apply(this, args)
+        // the result on this cached instance.
+        return memoizeCall(this, methodName, () =>
+          Type.prototype[methodName].apply(this)
         );
       },
     });
@@ -282,35 +186,6 @@ function getCachedType(Type) {
  */
 export const YearFactory = {
   /**
-   * Register cache hooks for a calculator type.
-   *
-   * @template T
-   * @param {YearType<T>} Type
-   * @param {YearFactoryTypeConfig} config
-   */
-  registerType(Type, config) {
-    typeConfigs.set(
-      Type,
-      /** @type {YearFactoryTypeConfig} */ ({
-        getInstanceKey: config.getInstanceKey,
-        getConstructorArg: config.getConstructorArg,
-      })
-    );
-  },
-
-  /**
-   * Register an adapter for caching method return values that need to be
-   * serialized before memoization.
-   *
-   * Later registrations win so specialized adapters can override broad ones.
-   *
-   * @param {ResultAdapter} adapter
-   */
-  registerResultAdapter(adapter) {
-    resultAdapters.unshift(adapter);
-  },
-
-  /**
    * Return a cached Year-like calculator for the requested calendar year.
    *
    * `Type` is typically `Year` or `ThreeYear`, but tests also use ad-hoc
@@ -323,16 +198,8 @@ export const YearFactory = {
    * @returns {T}
    */
   get(value, Type) {
-    const { getInstanceKey, getConstructorArg } = getTypeConfig(
-      /** @type {YearType<object>} */ (Type)
-    );
-    const key = getInstanceKey(value);
-    const constructorArg = getConstructorArg(value);
-
-    if (
-      (typeof key === "number" && Number.isNaN(key)) ||
-      (typeof key === "string" && key.length === 0)
-    ) {
+    const year = YearFactory.getYear(value);
+    if (Number.isNaN(year)) {
       throw new TypeError(`Unable to derive year from value: ${value}`);
     }
 
@@ -342,12 +209,12 @@ export const YearFactory = {
 
     const typeCache = cache.get(Type);
 
-    if (!typeCache.has(key)) {
+    if (!typeCache.has(year)) {
       const CachedType = getCachedType(Type);
-      typeCache.set(key, new CachedType(constructorArg));
+      typeCache.set(year, new CachedType(year));
     }
 
-    return typeCache.get(key);
+    return typeCache.get(year);
   },
 
   /**
@@ -375,13 +242,3 @@ export const YearFactory = {
     cache.clear();
   },
 };
-
-YearFactory.registerResultAdapter({
-  test: DateTime.isDateTime,
-  freeze(value) {
-    return value.toObject();
-  },
-  thaw(value) {
-    return DateTime.fromObject(value);
-  },
-});

--- a/lib/YearFactory.js
+++ b/lib/YearFactory.js
@@ -1,4 +1,5 @@
 const cache = new Map();
+const CACHED_VALUE = Symbol("cachedValue");
 
 /**
  * Factory/cache for Year-like calculators keyed by class type and calendar year.
@@ -55,31 +56,44 @@ export const YearFactory = {
    */
   createMemoizedProxy(instance) {
     const methodCache = new Map();
+    const wrapperCache = new Map();
 
     return new Proxy(instance, {
       get(target, prop, receiver) {
         const value = Reflect.get(target, prop, receiver);
 
-        if (typeof value !== "function") {
+        if (prop === "constructor" || typeof value !== "function") {
           return value;
         }
 
-        return (...args) => {
+        if (wrapperCache.has(prop)) {
+          return wrapperCache.get(prop);
+        }
+
+        const wrapped = (...args) => {
           if (!methodCache.has(prop)) {
             methodCache.set(prop, new Map());
           }
 
-          const cacheKey = JSON.stringify(args);
-          const propCache = methodCache.get(prop);
+          let node = methodCache.get(prop);
+          for (const arg of args) {
+            if (!node.has(arg)) {
+              node.set(arg, new Map());
+            }
+            node = node.get(arg);
+          }
 
-          if (propCache.has(cacheKey)) {
-            return propCache.get(cacheKey);
+          if (node.has(CACHED_VALUE)) {
+            return node.get(CACHED_VALUE);
           }
 
           const result = value.apply(target, args);
-          propCache.set(cacheKey, result);
+          node.set(CACHED_VALUE, result);
           return result;
         };
+
+        wrapperCache.set(prop, wrapped);
+        return wrapped;
       },
     });
   },

--- a/lib/YearFactory.js
+++ b/lib/YearFactory.js
@@ -1,0 +1,90 @@
+/**
+ * Factory/cache for Year-like calculators keyed by class type and calendar year.
+ */
+export class YearFactory {
+  /**
+   * @type {Map<Function, Map<number, object>>}
+   * @private
+   */
+  static _cache = new Map();
+
+  /**
+   * @param {number|string|Date|{year:number|string}} value
+   * @param {Function} Type
+   * @returns {object}
+   */
+  static get(value, Type) {
+    const year = this.getYear(value);
+    if (Number.isNaN(year)) {
+      throw new TypeError(`Unable to derive year from value: ${value}`);
+    }
+
+    if (!this._cache.has(Type)) {
+      this._cache.set(Type, new Map());
+    }
+
+    const typeCache = this._cache.get(Type);
+
+    if (!typeCache.has(year)) {
+      typeCache.set(year, this.createMemoizedProxy(new Type(year)));
+    }
+
+    return typeCache.get(year);
+  }
+
+  /**
+   * @param {number|string|Date|{year:number|string}} value
+   * @returns {number}
+   */
+  static getYear(value) {
+    if (value instanceof Date) {
+      return value.getFullYear();
+    }
+
+    if (value && typeof value === "object" && "year" in value) {
+      return parseInt(value.year, 10);
+    }
+
+    return parseInt(value, 10);
+  }
+
+  static clear() {
+    this._cache.clear();
+  }
+
+  /**
+   * Wraps an instance in a Proxy that memoizes method calls by method name + args.
+   * @param {object} instance
+   * @returns {object}
+   */
+  static createMemoizedProxy(instance) {
+    const methodCache = new Map();
+
+    return new Proxy(instance, {
+      get(target, prop, receiver) {
+        const value = Reflect.get(target, prop, receiver);
+
+        if (typeof value !== "function") {
+          return value;
+        }
+
+        return (...args) => {
+          if (!methodCache.has(prop)) {
+            methodCache.set(prop, new Map());
+          }
+
+          const cacheKey = JSON.stringify(args);
+          const propCache = methodCache.get(prop);
+
+          if (propCache.has(cacheKey)) {
+            return propCache.get(cacheKey);
+          }
+
+          const result = value.apply(target, args);
+          propCache.set(cacheKey, result);
+          return result;
+        };
+      },
+    });
+  }
+}

--- a/lib/YearFactory.js
+++ b/lib/YearFactory.js
@@ -1,14 +1,187 @@
+/**
+ * Object shape accepted by the factory when the caller passes a Luxon-style
+ * date-like value instead of a raw year.
+ * @typedef {{ year: number | string }} YearLikeObject
+ */
+
+/**
+ * Accepted inputs for deriving a calendar year.
+ * @typedef {number | string | Date | YearLikeObject} YearLikeValue
+ */
+
+/**
+ * Constructor shape for Year-like calculators.
+ * @template T
+ * @typedef {new (year: number) => T} YearType
+ */
+
+/**
+ * Nested argument-keyed memoization tree used per instance and per method.
+ * @typedef {Map<unknown, MemoNode | unknown>} MemoNode
+ */
+
+// Shared instances keyed first by calculator class, then by calendar year.
+// Example: cache.get(Year).get(2025) -> cached Year-like instance for 2025.
+/** @type {Map<YearType<object>, Map<number, object>>} */
 const cache = new Map();
+// Each source class gets exactly one generated memoizing subclass.
+/** @type {WeakMap<YearType<object>, YearType<object>>} */
+const cachedTypes = new WeakMap();
 const CACHED_VALUE = Symbol("cachedValue");
+const METHOD_CACHE = Symbol("methodCache");
+
+/**
+ * Collect all callable method names from a Year-like class and its prototypes.
+ *
+ * @param {YearType<object>} Type
+ * @returns {string[]}
+ */
+function getMethodNames(Type) {
+  // Walk the prototype chain so subclasses inherit wrapped versions of both
+  // their own methods and Year methods.
+  const names = new Set();
+  let prototype = Type.prototype;
+
+  while (prototype && prototype !== Object.prototype) {
+    for (const [name, descriptor] of Object.entries(
+      Object.getOwnPropertyDescriptors(prototype)
+    )) {
+      if (name === "constructor" || typeof descriptor.value !== "function") {
+        continue;
+      }
+
+      names.add(name);
+    }
+
+    prototype = Object.getPrototypeOf(prototype);
+  }
+
+  return [...names];
+}
+
+/**
+ * Resolve a memoized result for one method invocation on one cached instance.
+ *
+ * @template T
+ * @param {object & { [METHOD_CACHE]: Map<string, MemoNode> }} instance
+ * @param {string} methodName
+ * @param {unknown[]} args
+ * @param {() => T} invoke
+ * @returns {T}
+ */
+function memoizeCall(instance, methodName, args, invoke) {
+  // Cache entries are stored as a nested Map tree keyed by argument identity.
+  // That lets us distinguish values such as `undefined`, symbols, objects, and
+  // numbers without depending on fragile JSON serialization.
+  const methodCache = instance[METHOD_CACHE];
+
+  if (!methodCache.has(methodName)) {
+    methodCache.set(methodName, new Map());
+  }
+
+  let node = methodCache.get(methodName);
+  for (const arg of args) {
+    if (!node.has(arg)) {
+      node.set(arg, new Map());
+    }
+    node = node.get(arg);
+  }
+
+  if (node.has(CACHED_VALUE)) {
+    return node.get(CACHED_VALUE);
+  }
+
+  const result = invoke();
+  node.set(CACHED_VALUE, result);
+  return result;
+}
+
+/**
+ * Build a memoizing wrapper subclass for a Year-like calculator type.
+ *
+ * @template T
+ * @param {YearType<T>} Type
+ * @returns {YearType<T>}
+ */
+function createCachedType(Type) {
+  // We generate a subclass instead of using a Proxy so two things keep working:
+  // 1. `#private` fields on Year remain accessible.
+  // 2. Nested method calls such as getEndOfYear() -> getAdvent() flow back
+  //    through the wrapped methods on the instance and benefit from memoization.
+  class CachedType extends Type {
+    constructor(...args) {
+      super(...args);
+      // Store per-instance memoized results on a symbol so callers cannot
+      // accidentally depend on or mutate the cache shape.
+      Object.defineProperty(this, METHOD_CACHE, {
+        value: new Map(),
+      });
+      // Cached instances are shared process-wide, so freeze them after setup to
+      // avoid external mutation poisoning later callers.
+      Object.freeze(this);
+    }
+  }
+
+  for (const methodName of getMethodNames(Type)) {
+    Object.defineProperty(CachedType.prototype, methodName, {
+      configurable: true,
+      writable: true,
+      value(...args) {
+        // Resolve the original method from the source prototype, then memoize
+        // the result on this cached instance for this exact argument list.
+        return memoizeCall(this, methodName, args, () =>
+          Type.prototype[methodName].apply(this, args)
+        );
+      },
+    });
+  }
+
+  // Preserve the expected constructor identity for callers and tests:
+  // YearFactory.get(2025, Year).constructor === Year
+  Object.defineProperty(CachedType.prototype, "constructor", {
+    configurable: true,
+    writable: true,
+    value: Type,
+  });
+
+  return CachedType;
+}
+
+/**
+ * Return the generated memoizing subclass for the given source class.
+ *
+ * @template T
+ * @param {YearType<T>} Type
+ * @returns {YearType<T>}
+ */
+function getCachedType(Type) {
+  if (!cachedTypes.has(Type)) {
+    // Generating wrapper subclasses repeatedly is unnecessary churn, so hold on
+    // to one generated type per source class.
+    cachedTypes.set(
+      Type,
+      /** @type {YearType<object>} */ (createCachedType(Type))
+    );
+  }
+
+  return /** @type {YearType<T>} */ (cachedTypes.get(Type));
+}
 
 /**
  * Factory/cache for Year-like calculators keyed by class type and calendar year.
  */
 export const YearFactory = {
   /**
-   * @param {number|string|Date|{year:number|string}} value
-   * @param {Function} Type
-   * @returns {object}
+   * Return a cached Year-like calculator for the requested calendar year.
+   *
+   * `Type` is typically `Year` or `ThreeYear`, but tests also use ad-hoc
+   * subclasses to verify memoization behavior. Instances are shared by class and
+   * year, so `Year` 2025 and `ThreeYear` 2025 remain distinct cache entries.
+   *
+   * @template T
+   * @param {YearLikeValue} value
+   * @param {YearType<T>} Type
+   * @returns {T}
    */
   get(value, Type) {
     const year = YearFactory.getYear(value);
@@ -23,14 +196,19 @@ export const YearFactory = {
     const typeCache = cache.get(Type);
 
     if (!typeCache.has(year)) {
-      typeCache.set(year, YearFactory.createMemoizedProxy(new Type(year)));
+      const CachedType = getCachedType(Type);
+      typeCache.set(year, new CachedType(year));
     }
 
     return typeCache.get(year);
   },
 
   /**
-   * @param {number|string|Date|{year:number|string}} value
+   * Normalize the different "year-like" inputs callers pass into the factory.
+   * We accept raw years, JS Dates, and Luxon-style objects with a `year`
+   * property so Week/Series can pass their existing date values directly.
+   *
+   * @param {YearLikeValue} value
    * @returns {number}
    */
   getYear(value) {
@@ -46,55 +224,7 @@ export const YearFactory = {
   },
 
   clear() {
+    // Test helper: clear cached instances between assertions.
     cache.clear();
-  },
-
-  /**
-   * Wraps an instance in a Proxy that memoizes method calls by method name + args.
-   * @param {object} instance
-   * @returns {object}
-   */
-  createMemoizedProxy(instance) {
-    const methodCache = new Map();
-    const wrapperCache = new Map();
-
-    return new Proxy(instance, {
-      get(target, prop, receiver) {
-        const value = Reflect.get(target, prop, receiver);
-
-        if (prop === "constructor" || typeof value !== "function") {
-          return value;
-        }
-
-        if (wrapperCache.has(prop)) {
-          return wrapperCache.get(prop);
-        }
-
-        const wrapped = (...args) => {
-          if (!methodCache.has(prop)) {
-            methodCache.set(prop, new Map());
-          }
-
-          let node = methodCache.get(prop);
-          for (const arg of args) {
-            if (!node.has(arg)) {
-              node.set(arg, new Map());
-            }
-            node = node.get(arg);
-          }
-
-          if (node.has(CACHED_VALUE)) {
-            return node.get(CACHED_VALUE);
-          }
-
-          const result = value.apply(target, args);
-          node.set(CACHED_VALUE, result);
-          return result;
-        };
-
-        wrapperCache.set(prop, wrapped);
-        return wrapped;
-      },
-    });
   },
 };

--- a/lib/YearFactory.js
+++ b/lib/YearFactory.js
@@ -1,3 +1,5 @@
+import { DateTime } from "luxon";
+
 /**
  * Object shape accepted by the factory when the caller passes a Luxon-style
  * date-like value instead of a raw year.
@@ -12,7 +14,7 @@
 /**
  * Constructor shape for Year-like calculators.
  * @template T
- * @typedef {new (year: number) => T} YearType
+ * @typedef {new (value: unknown) => T} YearType
  */
 
 /**
@@ -20,15 +22,117 @@
  * @typedef {Map<unknown, MemoNode | unknown>} MemoNode
  */
 
+/**
+ * Configuration hooks for a cached calculator type.
+ *
+ * `getInstanceKey` determines when two inputs should share one cached instance.
+ * `getConstructorArg` transforms the incoming value before constructing the
+ * calculator. The defaults preserve the current Gregorian year-based behavior.
+ *
+ * @typedef {{
+ *   getInstanceKey?: (value: YearLikeValue) => string | number,
+ *   getConstructorArg?: (value: YearLikeValue) => unknown,
+ * }} YearFactoryTypeConfig
+ */
+
+/**
+ * Adapter for freezing and thawing cacheable method return values.
+ *
+ * @typedef {{
+ *   test: (value: unknown) => boolean,
+ *   freeze: (value: unknown) => unknown,
+ *   thaw: (value: unknown) => unknown,
+ * }} ResultAdapter
+ */
+
 // Shared instances keyed first by calculator class, then by calendar year.
 // Example: cache.get(Year).get(2025) -> cached Year-like instance for 2025.
-/** @type {Map<YearType<object>, Map<number, object>>} */
+/** @type {Map<YearType<object>, Map<string | number, object>>} */
 const cache = new Map();
 // Each source class gets exactly one generated memoizing subclass.
 /** @type {WeakMap<YearType<object>, YearType<object>>} */
 const cachedTypes = new WeakMap();
+/** @type {WeakMap<YearType<object>, YearFactoryTypeConfig>} */
+const typeConfigs = new WeakMap();
+/** @type {ResultAdapter[]} */
+const resultAdapters = [];
 const CACHED_VALUE = Symbol("cachedValue");
 const METHOD_CACHE = Symbol("methodCache");
+const UNCACHEABLE = Symbol("uncacheable");
+
+/**
+ * @param {YearLikeValue} value
+ * @returns {string | number}
+ */
+function defaultGetInstanceKey(value) {
+  return YearFactory.getYear(value);
+}
+
+/**
+ * @param {YearLikeValue} value
+ * @returns {unknown}
+ */
+function defaultGetConstructorArg(value) {
+  return YearFactory.getYear(value);
+}
+
+/**
+ * @param {YearType<object>} Type
+ * @returns {Required<YearFactoryTypeConfig>}
+ */
+function getTypeConfig(Type) {
+  const config = typeConfigs.get(Type);
+  return {
+    getInstanceKey: config?.getInstanceKey ?? defaultGetInstanceKey,
+    getConstructorArg: config?.getConstructorArg ?? defaultGetConstructorArg,
+  };
+}
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isPrimitive(value) {
+  return (
+    value === null ||
+    value === undefined ||
+    (typeof value !== "object" && typeof value !== "function")
+  );
+}
+
+/**
+ * @param {unknown} value
+ * @returns {{ kind: "raw", value: unknown } | { kind: "adapted", adapter: ResultAdapter, value: unknown } | typeof UNCACHEABLE}
+ */
+function freezeResult(value) {
+  if (isPrimitive(value)) {
+    return { kind: "raw", value };
+  }
+
+  for (const adapter of resultAdapters) {
+    if (adapter.test(value)) {
+      return {
+        kind: "adapted",
+        adapter,
+        value: adapter.freeze(value),
+      };
+    }
+  }
+
+  return UNCACHEABLE;
+}
+
+/**
+ * @param {{ kind: "raw", value: unknown } | { kind: "adapted", adapter: ResultAdapter, value: unknown }} entry
+ * @returns {unknown}
+ */
+function thawResult(entry) {
+  if (entry.kind === "raw") {
+    return entry.value;
+  }
+
+  return entry.adapter.thaw(entry.value);
+}
 
 /**
  * Collect all callable method names from a Year-like class and its prototypes.
@@ -88,12 +192,18 @@ function memoizeCall(instance, methodName, args, invoke) {
   }
 
   if (node.has(CACHED_VALUE)) {
-    return node.get(CACHED_VALUE);
+    return thawResult(node.get(CACHED_VALUE));
   }
 
   const result = invoke();
-  node.set(CACHED_VALUE, result);
-  return result;
+  const frozen = freezeResult(result);
+
+  if (frozen === UNCACHEABLE) {
+    return result;
+  }
+
+  node.set(CACHED_VALUE, frozen);
+  return thawResult(frozen);
 }
 
 /**
@@ -172,6 +282,35 @@ function getCachedType(Type) {
  */
 export const YearFactory = {
   /**
+   * Register cache hooks for a calculator type.
+   *
+   * @template T
+   * @param {YearType<T>} Type
+   * @param {YearFactoryTypeConfig} config
+   */
+  registerType(Type, config) {
+    typeConfigs.set(
+      Type,
+      /** @type {YearFactoryTypeConfig} */ ({
+        getInstanceKey: config.getInstanceKey,
+        getConstructorArg: config.getConstructorArg,
+      })
+    );
+  },
+
+  /**
+   * Register an adapter for caching method return values that need to be
+   * serialized before memoization.
+   *
+   * Later registrations win so specialized adapters can override broad ones.
+   *
+   * @param {ResultAdapter} adapter
+   */
+  registerResultAdapter(adapter) {
+    resultAdapters.unshift(adapter);
+  },
+
+  /**
    * Return a cached Year-like calculator for the requested calendar year.
    *
    * `Type` is typically `Year` or `ThreeYear`, but tests also use ad-hoc
@@ -184,8 +323,16 @@ export const YearFactory = {
    * @returns {T}
    */
   get(value, Type) {
-    const year = YearFactory.getYear(value);
-    if (Number.isNaN(year)) {
+    const { getInstanceKey, getConstructorArg } = getTypeConfig(
+      /** @type {YearType<object>} */ (Type)
+    );
+    const key = getInstanceKey(value);
+    const constructorArg = getConstructorArg(value);
+
+    if (
+      (typeof key === "number" && Number.isNaN(key)) ||
+      (typeof key === "string" && key.length === 0)
+    ) {
       throw new TypeError(`Unable to derive year from value: ${value}`);
     }
 
@@ -195,12 +342,12 @@ export const YearFactory = {
 
     const typeCache = cache.get(Type);
 
-    if (!typeCache.has(year)) {
+    if (!typeCache.has(key)) {
       const CachedType = getCachedType(Type);
-      typeCache.set(year, new CachedType(year));
+      typeCache.set(key, new CachedType(constructorArg));
     }
 
-    return typeCache.get(year);
+    return typeCache.get(key);
   },
 
   /**
@@ -228,3 +375,13 @@ export const YearFactory = {
     cache.clear();
   },
 };
+
+YearFactory.registerResultAdapter({
+  test: DateTime.isDateTime,
+  freeze(value) {
+    return value.toObject();
+  },
+  thaw(value) {
+    return DateTime.fromObject(value);
+  },
+});

--- a/lib/YearFactory.js
+++ b/lib/YearFactory.js
@@ -1,42 +1,38 @@
+const cache = new Map();
+
 /**
  * Factory/cache for Year-like calculators keyed by class type and calendar year.
  */
-export class YearFactory {
-  /**
-   * @type {Map<Function, Map<number, object>>}
-   * @private
-   */
-  static _cache = new Map();
-
+export const YearFactory = {
   /**
    * @param {number|string|Date|{year:number|string}} value
    * @param {Function} Type
    * @returns {object}
    */
-  static get(value, Type) {
-    const year = this.getYear(value);
+  get(value, Type) {
+    const year = YearFactory.getYear(value);
     if (Number.isNaN(year)) {
       throw new TypeError(`Unable to derive year from value: ${value}`);
     }
 
-    if (!this._cache.has(Type)) {
-      this._cache.set(Type, new Map());
+    if (!cache.has(Type)) {
+      cache.set(Type, new Map());
     }
 
-    const typeCache = this._cache.get(Type);
+    const typeCache = cache.get(Type);
 
     if (!typeCache.has(year)) {
-      typeCache.set(year, this.createMemoizedProxy(new Type(year)));
+      typeCache.set(year, YearFactory.createMemoizedProxy(new Type(year)));
     }
 
     return typeCache.get(year);
-  }
+  },
 
   /**
    * @param {number|string|Date|{year:number|string}} value
    * @returns {number}
    */
-  static getYear(value) {
+  getYear(value) {
     if (value instanceof Date) {
       return value.getFullYear();
     }
@@ -46,18 +42,18 @@ export class YearFactory {
     }
 
     return parseInt(value, 10);
-  }
+  },
 
-  static clear() {
-    this._cache.clear();
-  }
+  clear() {
+    cache.clear();
+  },
 
   /**
    * Wraps an instance in a Proxy that memoizes method calls by method name + args.
    * @param {object} instance
    * @returns {object}
    */
-  static createMemoizedProxy(instance) {
+  createMemoizedProxy(instance) {
     const methodCache = new Map();
 
     return new Proxy(instance, {
@@ -86,5 +82,5 @@ export class YearFactory {
         };
       },
     });
-  }
-}
+  },
+};

--- a/lib/YearFactory.test.js
+++ b/lib/YearFactory.test.js
@@ -38,14 +38,11 @@ describe("YearFactory", () => {
   });
 
   it("memoizes method calls on proxied instances", () => {
-    class CountingYear extends Year {
-      constructor(year) {
-        super(year);
-        this.calls = 0;
-      }
+    let calls = 0;
 
+    class CountingYear extends Year {
       getAdvent() {
-        this.calls += 1;
+        calls += 1;
         return super.getAdvent();
       }
     }
@@ -56,19 +53,34 @@ describe("YearFactory", () => {
     const advent2 = year.getAdvent();
 
     expect(advent1).toBe(advent2);
-    expect(year.calls).toBe(1);
+    expect(calls).toBe(1);
+  });
+
+  it("memoizes nested method composition across wrapped methods", () => {
+    let easterCalls = 0;
+
+    class CountingYear extends Year {
+      getEaster() {
+        easterCalls += 1;
+        return super.getEaster();
+      }
+    }
+
+    const year = YearFactory.get(2025, CountingYear);
+
+    year.getLent();
+    year.getTransfiguration();
+
+    expect(easterCalls).toBe(1);
   });
 
   it("does not collide memoization keys for non-JSON-serializable args", () => {
-    class KeySensitiveYear extends Year {
-      constructor(year) {
-        super(year);
-        this.calls = 0;
-      }
+    let calls = 0;
 
+    class KeySensitiveYear extends Year {
       getByValue(value) {
-        this.calls += 1;
-        return this.calls;
+        calls += 1;
+        return calls;
       }
     }
 
@@ -79,14 +91,14 @@ describe("YearFactory", () => {
     const symbolResult = year.getByValue(symbolArg);
 
     expect(undefinedResult).not.toBe(symbolResult);
-    expect(year.calls).toBe(2);
+    expect(calls).toBe(2);
   });
 
-  it("preserves constructor property semantics on proxied instances", () => {
+  it("does not expose the calendar year as a public mutable field", () => {
     const year = YearFactory.get(2025, Year);
 
-    expect(year.constructor).toBe(Year);
-    expect(year.constructor.name).toBe("Year");
+    expect("year" in year).toBe(false);
+    expect(Object.isFrozen(year)).toBe(true);
   });
 
   it("transparently memoizes Year and ThreeYear methods from the factory", () => {
@@ -95,5 +107,12 @@ describe("YearFactory", () => {
 
     expect(year.getEaster()).toBe(year.getEaster());
     expect(threeYear.getTransfiguration()).toBe(threeYear.getTransfiguration());
+  });
+
+  it("preserves constructor property semantics on cached instances", () => {
+    const year = YearFactory.get(2025, Year);
+
+    expect(year.constructor).toBe(Year);
+    expect(year.constructor.name).toBe("Year");
   });
 });

--- a/lib/YearFactory.test.js
+++ b/lib/YearFactory.test.js
@@ -2,6 +2,7 @@ import { DateTime, Settings } from "luxon";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { ThreeYear } from "./3year/Year.js";
+import { BaseYear } from "./BaseYear.js";
 import { Year } from "./Year.js";
 import { YearFactory } from "./YearFactory.js";
 
@@ -27,7 +28,9 @@ describe("YearFactory", () => {
     const year = YearFactory.get(2025, Year);
     const threeYear = YearFactory.get(2025, ThreeYear);
 
+    expect(year).toBeInstanceOf(BaseYear);
     expect(year).toBeInstanceOf(Year);
+    expect(threeYear).toBeInstanceOf(BaseYear);
     expect(threeYear).toBeInstanceOf(ThreeYear);
     expect(year).not.toBe(threeYear);
   });
@@ -75,23 +78,40 @@ describe("YearFactory", () => {
     expect(easterCalls).toBe(1);
   });
 
-  it("does not collide memoization keys for non-JSON-serializable args", () => {
-    let calls = 0;
+  it("memoizes nested composition for ThreeYear overrides and inherited methods", () => {
+    let easterCalls = 0;
 
-    class KeySensitiveYear extends Year {
-      getByValue(value) {
-        calls += 1;
-        return calls;
+    class CountingThreeYear extends ThreeYear {
+      getEaster() {
+        easterCalls += 1;
+        return super.getEaster();
       }
     }
 
-    const year = YearFactory.get(2025, KeySensitiveYear);
-    const symbolArg = Symbol("token");
+    const year = YearFactory.get(2025, CountingThreeYear);
 
-    const undefinedResult = year.getByValue(undefined);
-    const symbolResult = year.getByValue(symbolArg);
+    year.getLent();
+    year.getTransfiguration();
 
-    expect(undefinedResult).not.toBe(symbolResult);
+    expect(easterCalls).toBe(1);
+  });
+
+  it("does not memoize helper methods outside the BaseYear API", () => {
+    let calls = 0;
+
+    class HelperYear extends Year {
+      getByValue(value) {
+        calls += 1;
+        return `${value}:${calls}`;
+      }
+    }
+
+    const year = YearFactory.get(2025, HelperYear);
+
+    const first = year.getByValue("token");
+    const second = year.getByValue("token");
+
+    expect(first).not.toBe(second);
     expect(calls).toBe(2);
   });
 
@@ -123,35 +143,6 @@ describe("YearFactory", () => {
     expect(threeYear.getTransfiguration()).toEqual(
       threeYear.getTransfiguration()
     );
-  });
-
-  it("allows types to override their cache key and constructor input", () => {
-    class ShiftedYear extends Year {
-      constructor(year) {
-        super(year + 1);
-      }
-    }
-
-    YearFactory.registerType(ShiftedYear, {
-      getInstanceKey(value) {
-        return `shifted:${value.inputYear}`;
-      },
-      getConstructorArg(value) {
-        return value.baseYear;
-      },
-    });
-
-    const first = YearFactory.get(
-      { inputYear: 2025, baseYear: 2024 },
-      ShiftedYear
-    );
-    const second = YearFactory.get(
-      { inputYear: 2025, baseYear: 1900 },
-      ShiftedYear
-    );
-
-    expect(first).toBe(second);
-    expect(first.getChristmas()).toEqual(DateTime.local(2025, 12, 25));
   });
 
   it("preserves constructor property semantics on cached instances", () => {

--- a/lib/YearFactory.test.js
+++ b/lib/YearFactory.test.js
@@ -59,6 +59,36 @@ describe("YearFactory", () => {
     expect(year.calls).toBe(1);
   });
 
+  it("does not collide memoization keys for non-JSON-serializable args", () => {
+    class KeySensitiveYear extends Year {
+      constructor(year) {
+        super(year);
+        this.calls = 0;
+      }
+
+      getByValue(value) {
+        this.calls += 1;
+        return this.calls;
+      }
+    }
+
+    const year = YearFactory.get(2025, KeySensitiveYear);
+    const symbolArg = Symbol("token");
+
+    const undefinedResult = year.getByValue(undefined);
+    const symbolResult = year.getByValue(symbolArg);
+
+    expect(undefinedResult).not.toBe(symbolResult);
+    expect(year.calls).toBe(2);
+  });
+
+  it("preserves constructor property semantics on proxied instances", () => {
+    const year = YearFactory.get(2025, Year);
+
+    expect(year.constructor).toBe(Year);
+    expect(year.constructor.name).toBe("Year");
+  });
+
   it("transparently memoizes Year and ThreeYear methods from the factory", () => {
     const year = YearFactory.get(2025, Year);
     const threeYear = YearFactory.get(2025, ThreeYear);

--- a/lib/YearFactory.test.js
+++ b/lib/YearFactory.test.js
@@ -1,0 +1,69 @@
+import { DateTime } from "luxon";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ThreeYear } from "./3year/Year.js";
+import { Year } from "./Year.js";
+import { YearFactory } from "./YearFactory.js";
+
+describe("YearFactory", () => {
+  afterEach(() => {
+    YearFactory.clear();
+  });
+
+  it("reuses cached instances for the same year and type", () => {
+    const year1 = Year.get(2025);
+    const year2 = Year.get("2025");
+    expect(year1).toBe(year2);
+  });
+
+  it("creates separate instances for different years", () => {
+    const year2025 = Year.get(2025);
+    const year2026 = Year.get(2026);
+    expect(year2025).not.toBe(year2026);
+  });
+
+  it("creates separate caches per Year type", () => {
+    const year = Year.get(2025);
+    const threeYear = ThreeYear.get(2025);
+
+    expect(year).toBeInstanceOf(Year);
+    expect(threeYear).toBeInstanceOf(ThreeYear);
+    expect(year).not.toBe(threeYear);
+  });
+
+  it("normalizes date-like input by year", () => {
+    const byDate = Year.get(DateTime.local(2025, 10, 31));
+    const byYear = Year.get(2025);
+    expect(byDate).toBe(byYear);
+  });
+
+  it("memoizes method calls on proxied instances", () => {
+    class CountingYear extends Year {
+      constructor(year) {
+        super(year);
+        this.calls = 0;
+      }
+
+      getAdvent() {
+        this.calls += 1;
+        return super.getAdvent();
+      }
+    }
+
+    const year = YearFactory.get(2025, CountingYear);
+
+    const advent1 = year.getAdvent();
+    const advent2 = year.getAdvent();
+
+    expect(advent1).toBe(advent2);
+    expect(year.calls).toBe(1);
+  });
+
+  it("transparently memoizes Year and ThreeYear methods from the factory", () => {
+    const year = Year.get(2025);
+    const threeYear = ThreeYear.get(2025);
+
+    expect(year.getEaster()).toBe(year.getEaster());
+    expect(threeYear.getTransfiguration()).toBe(threeYear.getTransfiguration());
+  });
+});

--- a/lib/YearFactory.test.js
+++ b/lib/YearFactory.test.js
@@ -11,20 +11,20 @@ describe("YearFactory", () => {
   });
 
   it("reuses cached instances for the same year and type", () => {
-    const year1 = Year.get(2025);
-    const year2 = Year.get("2025");
+    const year1 = YearFactory.get(2025, Year);
+    const year2 = YearFactory.get("2025", Year);
     expect(year1).toBe(year2);
   });
 
   it("creates separate instances for different years", () => {
-    const year2025 = Year.get(2025);
-    const year2026 = Year.get(2026);
+    const year2025 = YearFactory.get(2025, Year);
+    const year2026 = YearFactory.get(2026, Year);
     expect(year2025).not.toBe(year2026);
   });
 
   it("creates separate caches per Year type", () => {
-    const year = Year.get(2025);
-    const threeYear = ThreeYear.get(2025);
+    const year = YearFactory.get(2025, Year);
+    const threeYear = YearFactory.get(2025, ThreeYear);
 
     expect(year).toBeInstanceOf(Year);
     expect(threeYear).toBeInstanceOf(ThreeYear);
@@ -32,8 +32,8 @@ describe("YearFactory", () => {
   });
 
   it("normalizes date-like input by year", () => {
-    const byDate = Year.get(DateTime.local(2025, 10, 31));
-    const byYear = Year.get(2025);
+    const byDate = YearFactory.get(DateTime.local(2025, 10, 31), Year);
+    const byYear = YearFactory.get(2025, Year);
     expect(byDate).toBe(byYear);
   });
 
@@ -60,8 +60,8 @@ describe("YearFactory", () => {
   });
 
   it("transparently memoizes Year and ThreeYear methods from the factory", () => {
-    const year = Year.get(2025);
-    const threeYear = ThreeYear.get(2025);
+    const year = YearFactory.get(2025, Year);
+    const threeYear = YearFactory.get(2025, ThreeYear);
 
     expect(year.getEaster()).toBe(year.getEaster());
     expect(threeYear.getTransfiguration()).toBe(threeYear.getTransfiguration());

--- a/lib/YearFactory.test.js
+++ b/lib/YearFactory.test.js
@@ -1,4 +1,4 @@
-import { DateTime } from "luxon";
+import { DateTime, Settings } from "luxon";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { ThreeYear } from "./3year/Year.js";
@@ -7,6 +7,7 @@ import { YearFactory } from "./YearFactory.js";
 
 describe("YearFactory", () => {
   afterEach(() => {
+    Settings.defaultZone = "system";
     YearFactory.clear();
   });
 
@@ -52,7 +53,7 @@ describe("YearFactory", () => {
     const advent1 = year.getAdvent();
     const advent2 = year.getAdvent();
 
-    expect(advent1).toBe(advent2);
+    expect(advent1).toEqual(advent2);
     expect(calls).toBe(1);
   });
 
@@ -101,12 +102,56 @@ describe("YearFactory", () => {
     expect(Object.isFrozen(year)).toBe(true);
   });
 
+  it("recreates DateTime results using the current Luxon zone", () => {
+    Settings.defaultZone = "UTC";
+    const year = YearFactory.get(2025, Year);
+    const christmasInUtc = year.getChristmas();
+
+    Settings.defaultZone = "America/New_York";
+    const christmasInNewYork = year.getChristmas();
+
+    expect(christmasInUtc.zoneName).toBe("UTC");
+    expect(christmasInNewYork.zoneName).toBe("America/New_York");
+    expect(christmasInUtc.toISODate()).toBe(christmasInNewYork.toISODate());
+  });
+
   it("transparently memoizes Year and ThreeYear methods from the factory", () => {
     const year = YearFactory.get(2025, Year);
     const threeYear = YearFactory.get(2025, ThreeYear);
 
-    expect(year.getEaster()).toBe(year.getEaster());
-    expect(threeYear.getTransfiguration()).toBe(threeYear.getTransfiguration());
+    expect(year.getEaster()).toEqual(year.getEaster());
+    expect(threeYear.getTransfiguration()).toEqual(
+      threeYear.getTransfiguration()
+    );
+  });
+
+  it("allows types to override their cache key and constructor input", () => {
+    class ShiftedYear extends Year {
+      constructor(year) {
+        super(year + 1);
+      }
+    }
+
+    YearFactory.registerType(ShiftedYear, {
+      getInstanceKey(value) {
+        return `shifted:${value.inputYear}`;
+      },
+      getConstructorArg(value) {
+        return value.baseYear;
+      },
+    });
+
+    const first = YearFactory.get(
+      { inputYear: 2025, baseYear: 2024 },
+      ShiftedYear
+    );
+    const second = YearFactory.get(
+      { inputYear: 2025, baseYear: 1900 },
+      ShiftedYear
+    );
+
+    expect(first).toBe(second);
+    expect(first.getChristmas()).toEqual(DateTime.local(2025, 12, 25));
   });
 
   it("preserves constructor property semantics on cached instances", () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,3 +8,4 @@ export { SimpleLoader } from "./SimpleLoader.js";
 export { Sundays } from "./Sundays.js";
 export { Week } from "./Week.js";
 export { Year } from "./Year.js";
+export { YearFactory } from "./YearFactory.js";

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 export { ThreeYearKeyLoader } from "./3year/KeyLoader.js";
 export { Series } from "./3year/Series.js";
 export { ThreeYearWeek } from "./3year/Week.js";
+export { BaseWeek } from "./BaseWeek.js";
 export { CalendarBuilder } from "./CalendarBuilder.js";
 export { KeyLoader } from "./KeyLoader.js";
 export { ProperSundays } from "./ProperSundays.js";

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ export { ThreeYearKeyLoader } from "./3year/KeyLoader.js";
 export { Series } from "./3year/Series.js";
 export { ThreeYearWeek } from "./3year/Week.js";
 export { BaseWeek } from "./BaseWeek.js";
+export { BaseYear } from "./BaseYear.js";
 export { CalendarBuilder } from "./CalendarBuilder.js";
 export { KeyLoader } from "./KeyLoader.js";
 export { ProperSundays } from "./ProperSundays.js";

--- a/lib/matchesProperDate.js
+++ b/lib/matchesProperDate.js
@@ -53,9 +53,9 @@ function getWeekday(date) {
  * presentation layer, which can show both observances while still making one of
  * them primary.
  *
- * @param {{ week?: number | null, month?: number | null, day?: number | null }} proper
- * @param {DateTime} date
- * @param {number} weekOfLectionary
+ * @param {import("./Loader.js").Proper} proper
+ * @param {import("luxon").DateTime} date
+ * @param {number | null} weekOfLectionary
  * @returns {boolean}
  */
 export function matchesProperDate(proper, date, weekOfLectionary) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,13 @@
 import Sundays from "./Sundays.js";
 
+/** @typedef {import("./Loader.js").Proper} Proper */
+/** @typedef {import("./Loader.js").ProperDatasetMap} ProperDatasetMap */
+
+/**
+ * @param {Proper[] | undefined | null} propers
+ * @param {number} type
+ * @returns {Proper | null}
+ */
 export function findProperByType(propers, type) {
   if (!Array.isArray(propers)) {
     return null;
@@ -7,7 +15,13 @@ export function findProperByType(propers, type) {
   return propers.find((proper) => proper.type === type) ?? null;
 }
 
+/**
+ * @param {Proper[] | undefined | null} propers
+ * @param {number[]} types
+ * @returns {Partial<Record<number, Proper>>}
+ */
 export function findPropersByType(propers, types) {
+  /** @type {Partial<Record<number, Proper>>} */
   const matches = {};
 
   if (!Array.isArray(propers) || !Array.isArray(types)) {
@@ -32,9 +46,13 @@ export function findPropersByType(propers, types) {
   return matches;
 }
 
+/**
+ * @param {Proper[] | undefined | null} propers
+ * @returns {boolean}
+ */
 export function hasReadings(propers) {
   const matches = findPropersByType(propers, [1, 2]);
-  return matches[1] && matches[2];
+  return Boolean(matches[1] && matches[2]);
 }
 
 /**
@@ -64,7 +82,8 @@ export function festivalHasPrecedence(week) {
  * Return the primary and secondary propers collections for a date where both
  * the ordinary lectionary and a festival may be present.
  *
- * @param {{ week?: number | null, lectionary?: any[], festivals?: any[] }} day
+ * @param {{ week?: number | null, lectionary?: Proper[], festivals?: Proper[] }} day
+ * @returns {{ primary: Proper[], secondary: Proper[] }}
  */
 export function getPrecedence(day) {
   const lectionary = day?.lectionary ?? [];
@@ -96,8 +115,8 @@ export function getPrecedence(day) {
  * Rendering follows precedence order, but only keeps collections with enough
  * readings to display. OT is optional; Epistle and Gospel are required.
  *
- * @param {{ week?: number | null, lectionary?: any[], festivals?: any[] }} day
- * @returns {any[][]}
+ * @param {{ week?: number | null, lectionary?: Proper[], festivals?: Proper[] }} day
+ * @returns {Proper[][]}
  */
 export function getDisplayPropers(day) {
   const { primary, secondary } = getPrecedence(day);
@@ -106,7 +125,8 @@ export function getDisplayPropers(day) {
 
 /**
  * Return the first collection with a color proper.
- * @param  {...any} allPropers
+ * @param  {...(Proper[] | undefined | null)} allPropers
+ * @returns {string | undefined}
  */
 export function findColor(...allPropers) {
   return allPropers.reduce((prev, current) => {

--- a/lib/weekHelpers.js
+++ b/lib/weekHelpers.js
@@ -1,0 +1,22 @@
+/**
+ * Find the Sunday closest to a given date. If that day is already a Sunday, it
+ * just returns the original date.
+ *
+ * @param {import("luxon").DateTime} date
+ * @returns {import("luxon").DateTime}
+ */
+export function getSunday(date) {
+  return date.weekday === 7 ? date : date.minus({ days: date.weekday });
+}
+
+/**
+ * Find the difference between two liturgical week anchor dates.
+ *
+ * @param {import("luxon").DateTime} week1
+ * @param {import("luxon").DateTime} week2
+ * @returns {number}
+ */
+export function getWeekDifference(week1, week2) {
+  const { weeks } = week2.diff(week1, ["weeks"]).toObject();
+  return weeks;
+}


### PR DESCRIPTION
### Motivation
- Reduce repeated construction and expensive date calculations by caching and memoizing `Year`-like instances per calendar year and type.
- Provide a single factory entrypoint to normalize year-like inputs and share cached calculators across consumers.
- Replace ad-hoc `new Year(...)` calls with a centralized `Year.get` helper to enable caching without changing existing public APIs.

### Description
- Adds a `YearFactory` that caches instances by `(Type, year)`, normalizes year-like inputs, and returns proxy-wrapped instances that memoize method calls by argument list via `YearFactory.get`.
- Adds a `static get` helper to `Year` that delegates to `YearFactory.get` so callers can obtain cached/memoized instances via `Year.get`.
- Replaces direct `new Year(...)` construction with `Year.get(...)` in `Week` and `3year/Series` so those classes use the cached factory instances.
- Exposes `YearFactory` from the package entry by adding it to `lib/index.js` and adds `YearFactory.clear` to support test cleanup.
- Adds unit tests `YearFactory.test.js` that verify caching behavior, per-type separation, input normalization, and memoization of proxied methods.

### Testing
- Ran the unit test suite with `vitest` including the new `YearFactory` tests, and all tests completed successfully.
- The new tests validate instance reuse for the same `(type, year)`, separation for different years and types, normalization of date-like inputs, and memoization of method calls via the proxy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dafe52c008832d8738a8e702459652)