### PR TITLE
Migrate from Luxon to Day.js

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,13 @@ Tests live alongside source files (`*.test.js` / `*.test.jsx`).
 
 **Date string format matters.** `new Date("2022-12-25")` parses as **UTC midnight**, which in US timezones resolves to Dec 24 locally. Always use `MM/DD/YYYY` format (`new Date("12/25/2022")`) when constructing dates for `Week` in tests — this matches the format used throughout `data/tests.json`.
 
-**Luxon Sunday is weekday 7, not 0.** The codebase normalizes Sunday to `0` in loader and week logic, but Luxon's `.weekday` returns `7` for Sunday. Tests that verify Sunday matching should account for this.
+**Public APIs are Date-only.** Exported library APIs accept JavaScript `Date`
+values and return fresh JavaScript `Date` instances at local midnight. Day.js
+is internal only.
+
+**Internal weekday matching uses Sunday = 0.** Day.js's `.day()` returns `0`
+for Sunday, and the lectionary datasets use that same convention. Tests that
+verify Sunday-matching behavior should assert against `0`.
 
 **Three-year series rolls over at Advent, not January 1.** `Series` is anchored to the liturgical year, so dates before Advent belong to the previous series even if the calendar year has changed.
 
@@ -125,7 +131,9 @@ When adding or changing any color, background, border, or outline:
 ## Key Domain Notes
 
 - The one-year calendar uses ~57 named liturgical weeks starting with Advent 1. The three-year calendar keeps the same Advent-through-Easter shape, then switches post-Pentecost Sundays to Proper 3-29.
-- Dates use **Luxon** (`DateTime`); Luxon treats Sunday as weekday `7`, which the codebase adjusts to `0` in some places.
+- Public library boundaries use **JavaScript `Date`** values. Internal
+  calculations use **Day.js**, whose `.day()` returns `0` for Sunday, matching
+  the lectionary datasets directly.
 - The one-year lectionary uses the historic 57-week cycle. The three-year lectionary uses Series A/B/C, removes the pre-Lent Gesima season, and maps post-Pentecost Sundays to Proper 3-29 (`58`-`84`).
 - Propers can be week-based or fixed-date. Two dates in the same liturgical week share movable propers; festivals and commemorations can also match directly by month/day.
 - Liturgical color is stored as a proper entry (type 25) alongside readings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,30 +14,30 @@ The codebase now supports two lectionary modes:
 ## Commands
 
 ```bash
-npm run start        # Vite dev server
-npm run build        # Production build
-npm run test         # Run Vitest tests
-npm run lint         # Biome check
-npm run lint:format  # Biome check with --write
+pnpm start        # Vite dev server
+pnpm build        # Production build
+pnpm test         # Run Vitest tests
+pnpm lint         # Biome check
+pnpm lint:format  # Biome check with --write
 ```
 
 **After every code change you MUST:**
-1. Run `npm run lint:format` to auto-format with Biome
-2. Run `npm run test` to verify all tests pass
+1. Run `pnpm lint:format` to auto-format with Biome
+2. Run `pnpm test` to verify all tests pass
 
 Run a single test file:
 ```bash
-npm run test -- Year.test.js
+pnpm test -- Year.test.js
 ```
 
 Watch mode:
 ```bash
-npm run test -- --watch
+pnpm test -- --watch
 ```
 
 Coverage report:
 ```bash
-npm run test -- --coverage
+pnpm test -- --coverage
 ```
 
 ## JavaScript Conventions

--- a/README.md
+++ b/README.md
@@ -37,11 +37,18 @@ The package name remains `@stanlemon/lectionary`, so imports still look like:
 import { Week } from "@stanlemon/lectionary";
 ```
 
-Node `24.14.1+` is the current supported runtime for this repository.
+Node `24.15.0+` is the current supported runtime for this repository.
 
 ## Usage
 
-Most calendar classes accept either a JavaScript `Date` or a Luxon `DateTime`.
+The public library contract is `Date`-only at the boundary:
+
+- exported APIs accept JavaScript `Date` values where they take dates
+- exported date-returning APIs return fresh JavaScript `Date` instances
+- all returned dates represent local calendar dates at local midnight
+
+Day.js remains an internal implementation detail and is not part of the public
+contract.
 
 ### One-Year Calendar
 
@@ -49,9 +56,15 @@ Most calendar classes accept either a JavaScript `Date` or a Luxon `DateTime`.
 import { Week, Year } from "@stanlemon/lectionary";
 
 const date = new Date(2026, 5, 14); // June 14, 2026
+const toDateKey = (value) =>
+  [
+    value.getFullYear(),
+    String(value.getMonth() + 1).padStart(2, "0"),
+    String(value.getDate()).padStart(2, "0"),
+  ].join("-");
 
 const week = new Week(date).getWeek();
-const easter = new Year(2026).getEaster().toISODate();
+const easter = toDateKey(new Year(2026).getEaster());
 
 console.log({ week, easter });
 ```

--- a/app/App.jsx
+++ b/app/App.jsx
@@ -1,6 +1,5 @@
 import "./App.css";
 
-import { DateTime } from "luxon";
 import { createRoot } from "react-dom/client";
 import { Route, Router, Switch } from "wouter";
 import { useHashLocation } from "wouter/use-hash-location";
@@ -29,6 +28,8 @@ function LectionaryToggle() {
 }
 
 export function App() {
+  const today = new Date();
+
   return (
     <LectionaryProvider>
       <header className="title-bar">
@@ -47,16 +48,13 @@ export function App() {
           </Route>
           <Route exact path="/today">
             <Day
-              year={DateTime.local().year}
-              month={DateTime.local().month}
-              day={DateTime.local().day}
+              year={today.getFullYear()}
+              month={today.getMonth() + 1}
+              day={today.getDate()}
             />
           </Route>
           <Route>
-            <Calendar
-              year={DateTime.local().year}
-              month={DateTime.local().month}
-            />
+            <Calendar year={today.getFullYear()} month={today.getMonth() + 1} />
           </Route>
         </Switch>
       </Router>

--- a/app/Calendar.jsx
+++ b/app/Calendar.jsx
@@ -1,8 +1,8 @@
-import { DateTime } from "luxon";
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "wouter";
 
 import { CalendarBuilder } from "../lib/CalendarBuilder";
+import { createLocalDate, isSameDay } from "../lib/date";
 import {
   findColor,
   findPropersByType,
@@ -10,6 +10,11 @@ import {
   getPrecedence,
   hasReadings,
 } from "../lib/utils";
+import {
+  formatDateKey,
+  formatLongDateNoPadding,
+  formatMonthYear,
+} from "./dateFormatting";
 import { useLectionary } from "./LectionaryContext";
 
 const weekdayHeaders = [
@@ -23,7 +28,7 @@ const weekdayHeaders = [
 ];
 
 function getYearAndMonthLabel({ year, month }) {
-  return DateTime.fromObject({ year, month, day: 1 }).toFormat("MMMM y");
+  return formatMonthYear(createLocalDate(year, month, 1));
 }
 
 function padNumber(v) {
@@ -85,10 +90,19 @@ function getReadingSection(propers, festivalsPropers) {
 }
 
 function CalendarDay({ day, selectedDay, onSelectDay }) {
-  const isToday = day?.date ? DateTime.local().hasSame(day.date, "day") : false;
+  const isToday = day?.date
+    ? isSameDay(
+        createLocalDate(
+          new Date().getFullYear(),
+          new Date().getMonth() + 1,
+          new Date().getDate()
+        ),
+        day.date
+      )
+    : false;
   const isSelected =
     selectedDay?.date && day?.date
-      ? selectedDay.date.hasSame(day.date, "day")
+      ? isSameDay(selectedDay.date, day.date)
       : false;
 
   if (!day?.date) {
@@ -114,7 +128,7 @@ function CalendarDay({ day, selectedDay, onSelectDay }) {
       day.sunday?.propers.lectionary
     )?.toLowerCase() ?? "none";
   const className = getDayClassName({ color, isToday, isSelected });
-  const isSunday = day.date.weekday === 7;
+  const isSunday = day.date.getDay() === 0;
   const dayNumberClassName = getDayNumberClassName({
     isSunday,
     hasDisplayedPropers: !isSunday && displayPropers.length > 0,
@@ -145,7 +159,7 @@ function CalendarDay({ day, selectedDay, onSelectDay }) {
       tabIndex={0}
     >
       <div>
-        <h3 className={dayNumberClassName}>{day.date.day}</h3>
+        <h3 className={dayNumberClassName}>{day.date.getDate()}</h3>
         <div className="day-readings">
           {readingSections.map(({ id, summary }) => {
             return (
@@ -223,11 +237,7 @@ function DayDetailPanel({ selectedDay, year, month }) {
     });
   }
 
-  const dateLabel = date.toLocaleString({
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-  });
+  const dateLabel = formatLongDateNoPadding(date);
 
   return (
     <div className="day-detail-panel">
@@ -255,7 +265,10 @@ function DayDetailPanel({ selectedDay, year, month }) {
           );
         })}
       </div>
-      <Link className="day-detail-link" to={`/${year}/${month}/${date.day}/`}>
+      <Link
+        className="day-detail-link"
+        to={`/${year}/${month}/${date.getDate()}/`}
+      >
         View full readings →
       </Link>
     </div>
@@ -276,7 +289,9 @@ export default function Calendar({ year: yearProp, month: monthProp }) {
 
   const selectedDay =
     selectedDayState?.monthKey === monthKey
-      ? (grid.flat().find((d) => d?.date?.day === selectedDayState.dayNumber) ??
+      ? (grid
+          .flat()
+          .find((d) => d?.date?.getDate() === selectedDayState.dayNumber) ??
         null)
       : null;
   const previousMonth = getLastMonth(year, month);
@@ -301,9 +316,9 @@ export default function Calendar({ year: yearProp, month: monthProp }) {
 
   function selectDay(day) {
     if (window.innerWidth <= 480) {
-      setSelectedDayState({ monthKey, dayNumber: day.date.day });
+      setSelectedDayState({ monthKey, dayNumber: day.date.getDate() });
     } else {
-      window.location.hash = `/${year}/${month}/${day.date.day}/`;
+      window.location.hash = `/${year}/${month}/${day.date.getDate()}/`;
     }
   }
 
@@ -337,11 +352,13 @@ export default function Calendar({ year: yearProp, month: monthProp }) {
           {grid.map((week) => {
             const firstDay = week.find((d) => d?.date);
             return (
-              <tr key={firstDay ? firstDay.date.toISODate() : "empty"}>
+              <tr key={firstDay ? formatDateKey(firstDay.date) : "empty"}>
                 {week.map((day, weekDay) => (
                   <CalendarDay
                     day={day}
-                    key={day?.date?.toISODate() ?? `empty-${weekDay}`}
+                    key={
+                      day?.date ? formatDateKey(day.date) : `empty-${weekDay}`
+                    }
                     onSelectDay={selectDay}
                     selectedDay={selectedDay}
                   />

--- a/app/Day.jsx
+++ b/app/Day.jsx
@@ -1,10 +1,19 @@
-import { DateTime } from "luxon";
 import { Fragment, useEffect } from "react";
 import { Link } from "wouter";
 
 import types from "../data/types.json";
+import { createLocalDate } from "../lib/date";
 import { findColor, findProperByType, getPrecedence } from "../lib/utils";
 import { Week } from "../lib/Week";
+import {
+  addDays,
+  formatDatePath,
+  formatLongDate,
+  formatLongDateNoPadding,
+  formatMonthName,
+  formatMonthPath,
+  formatWeekdayName,
+} from "./dateFormatting";
 import { useLectionary } from "./LectionaryContext";
 
 const typesById = {};
@@ -35,7 +44,9 @@ function getTitle(day) {
   const primaryTitle = findProperByType(primary, 0)?.text;
   const sundayTitle = findProperByType(day.sunday.lectionary, 0)?.text;
   const weekdayTitle =
-    day.date.weekday === 7 ? null : `${day.date.weekdayLong} of ${sundayTitle}`;
+    day.date.getDay() === 0
+      ? null
+      : `${formatWeekdayName(day.date)} of ${sundayTitle}`;
   return primaryTitle || weekdayTitle || sundayTitle;
 }
 
@@ -61,9 +72,9 @@ function getSection(propers, festivalsPropers) {
 
 export default function Day({ year, month, day: dayProp }) {
   const { loader } = useLectionary();
-  const date = DateTime.fromObject({ year, month, day: dayProp });
-  const yesterday = date.minus({ days: 1 });
-  const tomorrow = date.plus({ days: 1 });
+  const date = createLocalDate(year, month, dayProp);
+  const yesterday = addDays(date, -1);
+  const tomorrow = addDays(date, 1);
   const weekCalculator = new Week(date);
   const week = weekCalculator.getWeek();
   const sunday = weekCalculator.getSunday();
@@ -122,28 +133,21 @@ export default function Day({ year, month, day: dayProp }) {
   return (
     <div className="propers">
       <nav>
-        <Link to={`/${yesterday.toFormat("y/LL/dd")}/`}>
-          &laquo; {yesterday.toFormat("LLLL d, y")}
+        <Link to={`/${formatDatePath(yesterday)}/`}>
+          &laquo; {formatLongDateNoPadding(yesterday)}
         </Link>
-        <Link className="text-center" to={`/${date.toFormat("y/LL")}/`}>
-          {date.toFormat("LLLL")}
+        <Link className="text-center" to={`/${formatMonthPath(date)}/`}>
+          {formatMonthName(date)}
         </Link>
-        <Link to={`/${tomorrow.toFormat("y/LL/dd")}/`}>
-          {tomorrow.toFormat("LLLL d, y")} &raquo;
+        <Link to={`/${formatDatePath(tomorrow)}/`}>
+          {formatLongDateNoPadding(tomorrow)} &raquo;
         </Link>
       </nav>
 
       <br />
 
       <div className="day-date-row">
-        <h2 className={colorClassName}>
-          {date.toLocaleString({
-            // weekday: "long",
-            month: "long",
-            day: "2-digit",
-            year: "numeric",
-          })}
-        </h2>
+        <h2 className={colorClassName}>{formatLongDate(date)}</h2>
         {colorName && (
           <span className={`parament-pill parament-pill-${colorClassName}`}>
             {colorName}

--- a/app/dateFormatting.js
+++ b/app/dateFormatting.js
@@ -1,0 +1,56 @@
+function padNumber(value) {
+  return String(value).padStart(2, "0");
+}
+
+export function formatMonthYear(date) {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "long",
+    year: "numeric",
+  }).format(date);
+}
+
+export function formatLongDate(date) {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "long",
+    day: "2-digit",
+    year: "numeric",
+  }).format(date);
+}
+
+export function formatLongDateNoPadding(date) {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+export function formatMonthName(date) {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "long",
+  }).format(date);
+}
+
+export function formatWeekdayName(date) {
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "long",
+  }).format(date);
+}
+
+export function formatMonthPath(date) {
+  return `${date.getFullYear()}/${padNumber(date.getMonth() + 1)}`;
+}
+
+export function formatDatePath(date) {
+  return `${formatMonthPath(date)}/${padNumber(date.getDate())}`;
+}
+
+export function formatDateKey(date) {
+  return `${date.getFullYear()}-${padNumber(date.getMonth() + 1)}-${padNumber(date.getDate())}`;
+}
+
+export function addDays(date, days) {
+  const next = new Date(date.getTime());
+  next.setDate(next.getDate() + days);
+  return next;
+}

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/lib/3year/KeyLoader.js
+++ b/lib/3year/KeyLoader.js
@@ -1,3 +1,4 @@
+import { getLectionaryWeekday, toInternalDayjs } from "../date.js";
 import { Series } from "./Series.js";
 import { ThreeYearWeek } from "./Week.js";
 
@@ -40,13 +41,13 @@ export class ThreeYearKeyLoader {
    * Load propers for a given date.
    * The week number is computed internally via ThreeYearWeek so ordinary-time
    * Propers (weeks 58–84) resolve correctly regardless of what the caller passes.
-   * @param {import("luxon").DateTime} date
+   * @param {Date} date
    * @returns {import("../Loader.js").ProperDatasetMap}
    */
   load(date) {
+    const internalDate = toInternalDayjs(date, "ThreeYearKeyLoader.load");
     const weekOfLectionary = new ThreeYearWeek(date).getWeek();
-    // Luxon represents Sunday as weekday 7; normalize to 0
-    const weekday = date.weekday === 7 ? 0 : date.weekday;
+    const weekday = getLectionaryWeekday(internalDate);
 
     /**
      * @param {import("../Loader.js").Proper[]} entries
@@ -57,7 +58,8 @@ export class ThreeYearKeyLoader {
         .filter(
           (proper) =>
             (proper.week === weekOfLectionary && proper.day === weekday) ||
-            (proper.month === date.month && proper.day === date.day)
+            (proper.month === internalDate.month() + 1 &&
+              proper.day === internalDate.date())
         )
         .sort((a, b) => {
           if (a.week && !b.week) return -1;
@@ -65,7 +67,7 @@ export class ThreeYearKeyLoader {
           return 0;
         });
 
-    const seriesKey = new Series(date.toJSDate()).getSeries();
+    const seriesKey = new Series(date).getSeries();
     const lectionary = this.#series[seriesKey] ?? [];
 
     /** @type {import("../Loader.js").ProperDatasetMap} */

--- a/lib/3year/KeyLoader.test.js
+++ b/lib/3year/KeyLoader.test.js
@@ -1,9 +1,10 @@
-import { DateTime } from "luxon";
+import dayjs from "dayjs";
 import { describe, expect, it } from "vitest";
 
 import lsb3yrA from "../../data/lsb-3yr-a.json";
 import lsb3yrB from "../../data/lsb-3yr-b.json";
 import lsb3yrC from "../../data/lsb-3yr-c.json";
+import { createLocalDate } from "../date.js";
 import { ThreeYearKeyLoader } from "./KeyLoader.js";
 
 // Advent 2022 = Series A, Advent 2023 = Series B, Advent 2024 = Series C
@@ -22,7 +23,7 @@ describe("ThreeYearKeyLoader", () => {
   it("returns series A lectionary for a Series A date", () => {
     // Nov 27, 2022 = Advent 1, Series A (Christmas 2022 = Sunday → Advent 1 = Nov 27)
     const loader = new ThreeYearKeyLoader({ series: seriesData, festivals });
-    const result = loader.load(DateTime.local(2022, 11, 27), 1);
+    const result = loader.load(createLocalDate(2022, 11, 27), 1);
     expect(result.lectionary).toHaveLength(1);
     expect(result.lectionary[0].text).toBe("Advent 1 (A)");
   });
@@ -30,21 +31,21 @@ describe("ThreeYearKeyLoader", () => {
   it("returns series B lectionary for a Series B date", () => {
     // Dec 3, 2023 = Advent 1, Series B
     const loader = new ThreeYearKeyLoader({ series: seriesData, festivals });
-    const result = loader.load(DateTime.local(2023, 12, 3), 1);
+    const result = loader.load(createLocalDate(2023, 12, 3), 1);
     expect(result.lectionary[0].text).toBe("Advent 1 (B)");
   });
 
   it("returns series C lectionary for a Series C date", () => {
     // Dec 1, 2024 = Advent 1, Series C
     const loader = new ThreeYearKeyLoader({ series: seriesData, festivals });
-    const result = loader.load(DateTime.local(2024, 12, 1), 1);
+    const result = loader.load(createLocalDate(2024, 12, 1), 1);
     expect(result.lectionary[0].text).toBe("Advent 1 (C)");
   });
 
   it("returns shared datasets regardless of series", () => {
     const loader = new ThreeYearKeyLoader({ series: seriesData, festivals });
     // Jan 6 = Epiphany feast, matched by month+day
-    const result = loader.load(DateTime.local(2024, 1, 6), 99);
+    const result = loader.load(createLocalDate(2024, 1, 6), 99);
     expect(result.festivals).toHaveLength(1);
     expect(result.festivals[0].text).toBe("The Epiphany");
   });
@@ -54,20 +55,29 @@ describe("ThreeYearKeyLoader", () => {
       series: { A: [], B: [], C: [] },
       festivals: [],
     });
-    const result = loader.load(DateTime.local(2022, 12, 4), 1);
+    const result = loader.load(createLocalDate(2022, 12, 4), 1);
     expect(result.lectionary).toEqual([]);
     expect(result.festivals).toEqual([]);
   });
 
-  it("normalizes Sunday weekday 7 to 0 when matching propers", () => {
-    // Nov 27, 2022 is a Sunday (Luxon weekday 7), Advent 1, series A, week 1
+  it("matches Sunday propers with weekday 0", () => {
+    // Nov 27, 2022 is a Sunday, Advent 1, Series A, week 1.
     const proper = { week: 1, day: 0, month: null, type: 1, text: "Epistle" };
     const loader = new ThreeYearKeyLoader({
       series: { A: [proper], B: [], C: [] },
       festivals: [],
     });
-    const result = loader.load(DateTime.local(2022, 11, 27));
+    const result = loader.load(createLocalDate(2022, 11, 27));
     expect(result.lectionary).toContainEqual(proper);
+  });
+
+  it("rejects Day.js input", () => {
+    const loader = new ThreeYearKeyLoader({
+      series: seriesData,
+      festivals: [],
+    });
+
+    expect(() => loader.load(dayjs(new Date(2022, 10, 27)))).toThrow(TypeError);
   });
 
   it("sorts week-based propers before month/day propers", () => {
@@ -83,7 +93,7 @@ describe("ThreeYearKeyLoader", () => {
       series: { A: [monthProper, weekProper], B: [], C: [] },
       festivals: [],
     });
-    const result = loader.load(DateTime.local(2022, 11, 27));
+    const result = loader.load(createLocalDate(2022, 11, 27));
     expect(result.lectionary[0]).toEqual(weekProper);
     expect(result.lectionary[1]).toEqual(monthProper);
   });
@@ -95,7 +105,7 @@ describe("ThreeYearKeyLoader", () => {
       daily: [],
       commemorations: [],
     });
-    const result = loader.load(DateTime.local(2022, 12, 4), 1);
+    const result = loader.load(createLocalDate(2022, 12, 4), 1);
     expect(result).toHaveProperty("lectionary");
     expect(result).toHaveProperty("festivals");
     expect(result).toHaveProperty("daily");
@@ -117,7 +127,7 @@ describe("ThreeYearKeyLoader — Series A ordinary time 2026", () => {
   }
 
   it("returns Proper 5 for June 7, 2026 (first Sunday after Trinity)", () => {
-    const result = loader.load(DateTime.local(2026, 6, 7), 0);
+    const result = loader.load(createLocalDate(2026, 6, 7), 0);
     expect(proper(result, 0)).toBe("Proper 5");
     expect(proper(result, 19)).toBe("Hos. 5:15\u20136:6");
     expect(proper(result, 1)).toBe("Rom. 4:13-18");
@@ -125,7 +135,7 @@ describe("ThreeYearKeyLoader — Series A ordinary time 2026", () => {
   });
 
   it("returns Proper 15 for August 16, 2026", () => {
-    const result = loader.load(DateTime.local(2026, 8, 16), 0);
+    const result = loader.load(createLocalDate(2026, 8, 16), 0);
     expect(proper(result, 0)).toBe("Proper 15");
     expect(proper(result, 19)).toBe("Isaiah 56:1, 6-8");
     expect(proper(result, 1)).toBe("Rom. 11:1-2a, 13-15, 28-32");

--- a/lib/3year/Series.js
+++ b/lib/3year/Series.js
@@ -1,5 +1,4 @@
-import { DateTime } from "luxon";
-
+import { toInternalDayjs } from "../date.js";
 import { Year } from "../Year.js";
 import { YearFactory } from "../YearFactory.js";
 
@@ -7,17 +6,14 @@ import { YearFactory } from "../YearFactory.js";
  * Calculates the three-year lectionary series letter for a date.
  */
 export class Series {
-  /** @type {import("luxon").DateTime} */
+  /** @type {import("dayjs").Dayjs} */
   #date;
 
   /**
-   * @param {Date | import("luxon").DateTime} date
+   * @param {Date} date
    */
   constructor(date) {
-    if (!(date instanceof DateTime)) {
-      date = DateTime.fromJSDate(date);
-    }
-    this.#date = date.startOf("day");
+    this.#date = toInternalDayjs(date, "Series");
   }
 
   /**
@@ -30,9 +26,14 @@ export class Series {
    * @returns {"A"|"B"|"C"}
    */
   getSeries() {
-    const advent = YearFactory.get(this.#date, Year).getAdvent();
+    const advent = toInternalDayjs(
+      YearFactory.get(this.#date.year(), Year).getAdvent(),
+      "Year.getAdvent()"
+    );
     const adventYear =
-      this.#date >= advent ? this.#date.year : this.#date.year - 1;
+      this.#date.valueOf() >= advent.valueOf()
+        ? this.#date.year()
+        : this.#date.year() - 1;
     return ["A", "B", "C"][adventYear % 3];
   }
 }

--- a/lib/3year/Series.test.js
+++ b/lib/3year/Series.test.js
@@ -1,4 +1,4 @@
-import { DateTime } from "luxon";
+import dayjs from "dayjs";
 import { describe, expect, it } from "vitest";
 import { Year } from "../Year.js";
 import { Series } from "./Series.js";
@@ -32,14 +32,17 @@ describe("Series.getSeries", () => {
     // The day before Advent 2023 (Dec 2 2023) is still Series A
     const year = new Year(2023);
     const advent = year.getAdvent();
-    const dayBefore = advent.minus({ days: 1 });
-    expect(new Series(dayBefore.toJSDate()).getSeries()).toBe("A");
+    const dayBefore = new Date(
+      advent.getFullYear(),
+      advent.getMonth(),
+      advent.getDate() - 1
+    );
+    expect(new Series(dayBefore).getSeries()).toBe("A");
     // Advent 2023 itself is Series B
-    expect(new Series(advent.toJSDate()).getSeries()).toBe("B");
+    expect(new Series(advent).getSeries()).toBe("B");
   });
 
-  it("accepts a Luxon DateTime", () => {
-    const dt = DateTime.fromISO("2023-12-03");
-    expect(new Series(dt).getSeries()).toBe("B");
+  it("rejects Day.js input", () => {
+    expect(() => new Series(dayjs(new Date(2023, 11, 3)))).toThrow(TypeError);
   });
 });

--- a/lib/3year/Week.js
+++ b/lib/3year/Week.js
@@ -1,5 +1,4 @@
-import { DateTime } from "luxon";
-
+import { toInternalDayjs, toPublicDate } from "../date.js";
 import ProperSundays from "../ProperSundays.js";
 import { getSunday, getWeekDifference } from "../weekHelpers.js";
 import { YearFactory } from "../YearFactory.js";
@@ -10,30 +9,26 @@ import { ThreeYear } from "./Year.js";
  */
 /** @implements {import("../BaseWeek.js").BaseWeek} */
 export class ThreeYearWeek {
-  /** @type {import("luxon").DateTime} */
+  /** @type {import("dayjs").Dayjs} */
   #date;
 
   /** @type {ThreeYear} */
   #year;
 
   /**
-   * @param {Date | import("luxon").DateTime} date
+   * @param {Date} date
    */
   constructor(date) {
-    if (!(date instanceof DateTime)) {
-      date = DateTime.fromJSDate(date);
-    }
-
-    this.#date = date.startOf("day");
-    this.#year = YearFactory.get(this.#date, ThreeYear);
+    this.#date = toInternalDayjs(date, "ThreeYearWeek");
+    this.#year = YearFactory.get(this.#date.year(), ThreeYear);
   }
 
   /**
    * Find the Sunday closest to the date we're calculating off. If that day is a Sunday, it just returns that date.
-   * @returns {DateTime}
+   * @returns {Date}
    */
   getSunday() {
-    return getSunday(this.#date);
+    return toPublicDate(getSunday(this.#date));
   }
 
   /**
@@ -45,33 +40,48 @@ export class ThreeYearWeek {
    */
   getWeek() {
     const year = this.#year;
-    const advent = year.getAdvent();
-    const epiphany = year.getEpiphany();
-    const epiphanySunday = year.getEpiphanySunday();
-    const transfiguration = year.getTransfiguration();
-    const lent = year.getLent();
+    const advent = toInternalDayjs(year.getAdvent(), "ThreeYear.getAdvent()");
+    const epiphany = toInternalDayjs(
+      year.getEpiphany(),
+      "ThreeYear.getEpiphany()"
+    );
+    const epiphanySunday = toInternalDayjs(
+      year.getEpiphanySunday(),
+      "ThreeYear.getEpiphanySunday()"
+    );
+    const transfiguration = toInternalDayjs(
+      year.getTransfiguration(),
+      "ThreeYear.getTransfiguration()"
+    );
+    const lent = toInternalDayjs(year.getLent(), "ThreeYear.getLent()");
     // getPentecost() = Easter + 7 weeks (actual Pentecost Sunday).
     // Trinity Sunday is one week later = Easter + 8 weeks.
-    const trinitySunday = year.getPentecost().plus({ weeks: 1 });
-    const sunday = this.getSunday();
+    const trinitySunday = toInternalDayjs(
+      year.getPentecost(),
+      "ThreeYear.getPentecost()"
+    ).add(1, "week");
+    const sunday = getSunday(this.#date);
 
     // Christmas on a Sunday — caller handles this week
-    if (sunday.month === 12 && sunday.day === 25) {
+    if (sunday.month() === 11 && sunday.date() === 25) {
       return null;
     }
 
     // Advent and beyond (into the next liturgical year)
-    if (sunday >= advent) {
+    if (sunday.valueOf() >= advent.valueOf()) {
       return 1 + getWeekDifference(advent, sunday);
     }
 
     // Before Epiphany (Sunday after Christmas, etc.)
-    if (sunday < epiphany) {
+    if (sunday.valueOf() < epiphany.valueOf()) {
       return 6 - getWeekDifference(sunday, epiphanySunday);
     }
 
     // Epiphany season through Transfiguration Sunday
-    if (sunday >= epiphany && sunday <= transfiguration) {
+    if (
+      sunday.valueOf() >= epiphany.valueOf() &&
+      sunday.valueOf() <= transfiguration.valueOf()
+    ) {
       if (sunday.valueOf() === transfiguration.valueOf()) {
         return 12;
       }
@@ -82,14 +92,17 @@ export class ThreeYearWeek {
     }
 
     // Lent through Trinity Sunday (weeks 16–30)
-    if (sunday > transfiguration && sunday <= trinitySunday) {
+    if (
+      sunday.valueOf() > transfiguration.valueOf() &&
+      sunday.valueOf() <= trinitySunday.valueOf()
+    ) {
       return 16 + getWeekDifference(lent, sunday);
     }
 
     // Ordinary Time — ProperSundays calendar-date lookup.
     // Covers the first Sunday after Trinity through Christ the King (Proper 29),
     // which ends Nov 26 — the Sunday after that is always Advent 1.
-    const monthDay = `${String(sunday.month).padStart(2, "0")}-${String(sunday.day).padStart(2, "0")}`;
+    const monthDay = sunday.format("MM-DD");
     for (const [week, range] of Object.entries(ProperSundays)) {
       if (monthDay >= range.START && monthDay <= range.END) {
         return Number(week);

--- a/lib/3year/Week.test.js
+++ b/lib/3year/Week.test.js
@@ -1,4 +1,6 @@
+import dayjs from "dayjs";
 import { describe, expect, it } from "vitest";
+import { formatDateKey } from "../date.js";
 import Sundays from "../Sundays.js";
 import { ThreeYearWeek } from "./Week.js";
 
@@ -22,6 +24,32 @@ describe("ThreeYearWeek — Advent", () => {
 describe("ThreeYearWeek — Christmas null", () => {
   it("Dec 25 on Sunday returns null (2022)", () =>
     expect(week("12/25/2022")).toBeNull());
+});
+
+describe("ThreeYearWeek — Date normalization", () => {
+  it("normalizes Date inputs to the start of the local day", () => {
+    const sunday = new ThreeYearWeek(new Date(2026, 1, 15, 18, 30)).getSunday();
+
+    expect(sunday).toBeInstanceOf(Date);
+    expect(formatDateKey(sunday)).toBe("2026-02-15");
+    expect(sunday.getHours()).toBe(0);
+    expect(sunday.getMinutes()).toBe(0);
+  });
+
+  it("rejects Day.js input", () => {
+    expect(
+      () => new ThreeYearWeek(dayjs(new Date(2026, 1, 15, 18, 30)))
+    ).toThrow(TypeError);
+  });
+
+  it("returns a fresh Sunday Date each time", () => {
+    const week = new ThreeYearWeek(new Date("02/18/2026"));
+    const sunday = week.getSunday();
+
+    sunday.setDate(1);
+
+    expect(formatDateKey(week.getSunday())).toBe("2026-02-15");
+  });
 });
 
 describe("ThreeYearWeek — Before Epiphany", () => {

--- a/lib/3year/Year.js
+++ b/lib/3year/Year.js
@@ -1,3 +1,4 @@
+import { toInternalDayjs, toPublicDate } from "../date.js";
 import { Year } from "../Year.js";
 
 /**
@@ -13,10 +14,11 @@ export class ThreeYear extends Year {
    * In the three-year calendar there is no Gesima/pre-Lent season, so
    * Transfiguration lands one week before Ash Wednesday.
    *
-   * @returns {import("luxon").DateTime}
+   * @returns {Date}
    */
   getTransfiguration() {
     // Sunday before Ash Wednesday = Easter − 7 weeks (no pre-Lent season)
-    return this.getEaster().minus({ weeks: 7 });
+    const easter = toInternalDayjs(this.getEaster(), "ThreeYear.getEaster()");
+    return toPublicDate(easter.subtract(7, "week"));
   }
 }

--- a/lib/3year/Year.test.js
+++ b/lib/3year/Year.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { formatDateKey } from "../date.js";
 import { Year } from "../Year.js";
 import { ThreeYear } from "./Year.js";
 
@@ -6,35 +7,41 @@ describe("ThreeYear.getTransfiguration", () => {
   it("is Easter minus 7 weeks", () => {
     const year = new ThreeYear(2026);
     const easter = year.getEaster();
-    expect(year.getTransfiguration().toISODate()).toBe(
-      easter.minus({ weeks: 7 }).toISODate()
+    const expected = new Date(
+      easter.getFullYear(),
+      easter.getMonth(),
+      easter.getDate() - 49
+    );
+
+    expect(formatDateKey(year.getTransfiguration())).toBe(
+      formatDateKey(expected)
     );
   });
 
   it("differs from the 1-year Transfiguration (Easter minus 10 weeks)", () => {
     const year3 = new ThreeYear(2025);
     const year1 = new Year(2025);
-    expect(year3.getTransfiguration().toISODate()).not.toBe(
-      year1.getTransfiguration().toISODate()
+    expect(formatDateKey(year3.getTransfiguration())).not.toBe(
+      formatDateKey(year1.getTransfiguration())
     );
   });
 
   it("returns correct date for 2025 (Easter Apr 20)", () => {
     // Easter 2025 = Apr 20; Apr 20 − 7 weeks = Mar 2
     const year = new ThreeYear(2025);
-    expect(year.getTransfiguration().toISODate()).toBe("2025-03-02");
+    expect(formatDateKey(year.getTransfiguration())).toBe("2025-03-02");
   });
 
   it("returns correct date for 2024 (Easter Mar 31)", () => {
     // Easter 2024 = Mar 31; − 7 weeks = Feb 11
     const year = new ThreeYear(2024);
-    expect(year.getTransfiguration().toISODate()).toBe("2024-02-11");
+    expect(formatDateKey(year.getTransfiguration())).toBe("2024-02-11");
   });
 
   it("returns correct date for 2026 (Easter Apr 5)", () => {
     // Easter 2026 = Apr 5; − 7 weeks = Feb 15
     const year = new ThreeYear(2026);
-    expect(year.getTransfiguration().toISODate()).toBe("2026-02-15");
+    expect(formatDateKey(year.getTransfiguration())).toBe("2026-02-15");
   });
 });
 
@@ -42,18 +49,35 @@ describe("ThreeYear inherits Year methods unchanged", () => {
   it("getAdvent matches Year.getAdvent", () => {
     const year3 = new ThreeYear(2025);
     const year1 = new Year(2025);
-    expect(year3.getAdvent().toISODate()).toBe(year1.getAdvent().toISODate());
+    expect(formatDateKey(year3.getAdvent())).toBe(
+      formatDateKey(year1.getAdvent())
+    );
   });
 
   it("getEaster matches Year.getEaster", () => {
     const year3 = new ThreeYear(2024);
     const year1 = new Year(2024);
-    expect(year3.getEaster().toISODate()).toBe(year1.getEaster().toISODate());
+    expect(formatDateKey(year3.getEaster())).toBe(
+      formatDateKey(year1.getEaster())
+    );
   });
 
   it("getLent matches Year.getLent", () => {
     const year3 = new ThreeYear(2026);
     const year1 = new Year(2026);
-    expect(year3.getLent().toISODate()).toBe(year1.getLent().toISODate());
+    expect(formatDateKey(year3.getLent())).toBe(formatDateKey(year1.getLent()));
+  });
+
+  it("returns Date instances from inherited and overridden getters", () => {
+    const year = new ThreeYear(2026);
+
+    [
+      year.getAdvent(),
+      year.getEaster(),
+      year.getLent(),
+      year.getTransfiguration(),
+    ].forEach((value) => {
+      expect(value).toBeInstanceOf(Date);
+    });
   });
 });

--- a/lib/BaseWeek.js
+++ b/lib/BaseWeek.js
@@ -11,7 +11,7 @@ export class BaseWeek {
   /**
    * Return the Sunday that anchors the current date's liturgical week.
    *
-   * @returns {import("luxon").DateTime}
+   * @returns {Date}
    */
   getSunday() {}
 

--- a/lib/BaseYear.js
+++ b/lib/BaseYear.js
@@ -22,84 +22,84 @@ export class BaseYear {
   }
 
   /**
-   * @returns {import("luxon").DateTime}
+   * @returns {Date}
    */
   getAdvent() {
     return this.#notImplemented("getAdvent");
   }
 
   /**
-   * @returns {import("luxon").DateTime}
+   * @returns {Date}
    */
   getChristmas() {
     return this.#notImplemented("getChristmas");
   }
 
   /**
-   * @returns {import("luxon").DateTime}
+   * @returns {Date}
    */
   getEpiphany() {
     return this.#notImplemented("getEpiphany");
   }
 
   /**
-   * @returns {import("luxon").DateTime}
+   * @returns {Date}
    */
   getEpiphanySunday() {
     return this.#notImplemented("getEpiphanySunday");
   }
 
   /**
-   * @returns {import("luxon").DateTime}
+   * @returns {Date}
    */
   getTransfiguration() {
     return this.#notImplemented("getTransfiguration");
   }
 
   /**
-   * @returns {import("luxon").DateTime}
+   * @returns {Date}
    */
   getAshWednesday() {
     return this.#notImplemented("getAshWednesday");
   }
 
   /**
-   * @returns {import("luxon").DateTime}
+   * @returns {Date}
    */
   getLent() {
     return this.#notImplemented("getLent");
   }
 
   /**
-   * @returns {import("luxon").DateTime}
+   * @returns {Date}
    */
   getEaster() {
     return this.#notImplemented("getEaster");
   }
 
   /**
-   * @returns {import("luxon").DateTime}
+   * @returns {Date}
    */
   getTrinity() {
     return this.#notImplemented("getTrinity");
   }
 
   /**
-   * @returns {import("luxon").DateTime}
+   * @returns {Date}
    */
   getPentecost() {
     return this.#notImplemented("getPentecost");
   }
 
   /**
-   * @returns {import("luxon").DateTime}
+   * @returns {Date}
    */
   getLastSunday() {
     return this.#notImplemented("getLastSunday");
   }
 
   /**
-   * @returns {import("luxon").DateTime}
+   * @returns {Date}
    */
   getEndOfYear() {
     return this.#notImplemented("getEndOfYear");

--- a/lib/CalendarBuilder.js
+++ b/lib/CalendarBuilder.js
@@ -1,6 +1,21 @@
-import { DateTime } from "luxon";
-
+import { cloneDate, createLocalDayjs, toPublicDate } from "./date.js";
 import { Week } from "./Week.js";
+
+function createSundaySnapshot(day) {
+  return {
+    ...day,
+    date: cloneDate(day.date),
+    sunday: null,
+  };
+}
+
+function cloneSundaySnapshot(day) {
+  return {
+    ...day,
+    date: cloneDate(day.date),
+    sunday: null,
+  };
+}
 
 /**
  * Build a calendar grid for a given month.
@@ -23,9 +38,9 @@ export class CalendarBuilder {
 
   /**
    * @template TPropers
-   * @param {{ load(date: import("luxon").DateTime, weekOfLectionary: number | null): TPropers }} loader
+   * @param {{ load(date: Date, weekOfLectionary: number | null): TPropers }} loader
    * @returns {Array<Array<{
-   *   date: import("luxon").DateTime,
+   *   date: Date,
    *   day: number,
    *   week: number | null,
    *   propers: TPropers,
@@ -33,25 +48,18 @@ export class CalendarBuilder {
    * } | null>>}
    */
   build(loader) {
-    const first = DateTime.local(this.#year, this.#month, 1, 0, 0, 0);
-    const last = DateTime.local(
-      this.#year,
-      this.#month,
-      first.daysInMonth,
-      0,
-      0,
-      0
-    );
+    const first = createLocalDayjs(this.#year, this.#month, 1);
+    const last = createLocalDayjs(this.#year, this.#month, first.daysInMonth());
 
     let current = first;
 
     // Rewind to the first column of the first row
-    if (first.weekday !== 7) {
-      current = current.minus({ days: first.weekday });
+    if (first.day() !== 0) {
+      current = current.subtract(first.day(), "day");
     }
 
     /** @type {Array<Array<{
-     *   date: import("luxon").DateTime,
+     *   date: Date,
      *   day: number,
      *   week: number | null,
      *   propers: TPropers,
@@ -60,31 +68,34 @@ export class CalendarBuilder {
     const grid = [];
 
     let row = 0;
-    let sunday = null;
-
-    while (current <= last) {
+    while (current.valueOf() <= last.valueOf()) {
       // Each row spans a single Sunday-through-Saturday liturgical week.
-      const weekOfLectionary = new Week(current).getWeek();
+      const weekOfLectionary = new Week(toPublicDate(current)).getWeek();
+      let sunday = null;
 
       for (let col = 0; col <= 6; col++) {
+        const publicDate = toPublicDate(current);
         const day = {
-          date: current,
+          date: cloneDate(publicDate),
           day: col + 1,
           week: weekOfLectionary,
-          propers: loader.load(current, weekOfLectionary),
-          sunday,
+          propers: loader.load(cloneDate(publicDate), weekOfLectionary),
+          sunday: sunday ? cloneSundaySnapshot(sunday) : null,
         };
 
         if (!grid[row]) {
           grid[row] = new Array(7).fill(null, 0, 7);
-          sunday = day;
+          sunday = createSundaySnapshot(day);
         }
 
-        if (current >= first && current <= last) {
+        if (
+          current.valueOf() >= first.valueOf() &&
+          current.valueOf() <= last.valueOf()
+        ) {
           grid[row][col] = day;
         }
 
-        current = current.plus({ days: 1 });
+        current = current.add(1, "day");
       }
 
       row++;

--- a/lib/CalendarBuilder.test.js
+++ b/lib/CalendarBuilder.test.js
@@ -1,6 +1,5 @@
-import { DateTime } from "luxon";
-
 import { CalendarBuilder } from "./CalendarBuilder.js";
+import { formatDateKey } from "./date.js";
 
 describe("CalendarBuilder", () => {
   const mockLoader = { load: () => {} };
@@ -12,13 +11,10 @@ describe("CalendarBuilder", () => {
     expect(grid).not.toBeNull();
 
     // First of the month is in the right grid position
-    expect(DateTime.local(2021, 1, 1).hasSame(grid[0][5].date, "day")).toBe(
-      true
-    );
+    expect(grid[0][5].date).toBeInstanceOf(Date);
+    expect(formatDateKey(grid[0][5].date)).toBe("2021-01-01");
     // Last of the month is in the right grid position
-    expect(DateTime.local(2021, 1, 31).hasSame(grid[5][0].date, "day")).toBe(
-      true
-    );
+    expect(formatDateKey(grid[5][0].date)).toBe("2021-01-31");
 
     expect(grid[0][0]).toBe(null);
     expect(grid[0][1]).toBe(null);
@@ -63,14 +59,10 @@ describe("CalendarBuilder", () => {
     expect(grid).toHaveLength(4);
 
     // First cell is Feb 1, no leading nulls
-    expect(DateTime.local(2015, 2, 1).hasSame(grid[0][0].date, "day")).toBe(
-      true
-    );
+    expect(formatDateKey(grid[0][0].date)).toBe("2015-02-01");
 
     // Last cell is Feb 28, no trailing nulls
-    expect(DateTime.local(2015, 2, 28).hasSame(grid[3][6].date, "day")).toBe(
-      true
-    );
+    expect(formatDateKey(grid[3][6].date)).toBe("2015-02-28");
 
     // Every cell in the grid is populated
     grid.forEach((week) => {
@@ -81,21 +73,16 @@ describe("CalendarBuilder", () => {
   });
 
   it("month starting on Sunday places first day in first column", () => {
-    // August 2021 starts on a Sunday (Luxon weekday 7)
     const calendarBuilder = new CalendarBuilder(2021, 8);
     const grid = calendarBuilder.build(mockLoader);
 
     expect(grid).not.toBeNull();
 
     // August 1 should be in column 0 (Sunday) of the first row — no rewind needed
-    expect(DateTime.local(2021, 8, 1).hasSame(grid[0][0].date, "day")).toBe(
-      true
-    );
+    expect(formatDateKey(grid[0][0].date)).toBe("2021-08-01");
 
     // August 31 (Tuesday) should be in column 2 of the fifth row
-    expect(DateTime.local(2021, 8, 31).hasSame(grid[4][2].date, "day")).toBe(
-      true
-    );
+    expect(formatDateKey(grid[4][2].date)).toBe("2021-08-31");
 
     // Trailing cells after the 31st should be null
     expect(grid[4][3]).toBe(null);
@@ -105,5 +92,51 @@ describe("CalendarBuilder", () => {
 
     // Only 5 rows for this month
     expect(grid[5]).toBeUndefined();
+  });
+
+  it("stores local-midnight Date values in the grid", () => {
+    const calendarBuilder = new CalendarBuilder(2021, 12);
+    const grid = calendarBuilder.build(mockLoader);
+    const date = grid[1][0].date;
+
+    expect(date).toBeInstanceOf(Date);
+    expect(formatDateKey(date)).toBe("2021-12-05");
+    expect(date.getHours()).toBe(0);
+    expect(date.getMinutes()).toBe(0);
+  });
+
+  it("clones dates passed to the loader", () => {
+    const loader = {
+      load(date) {
+        date.setDate(1);
+        return [];
+      },
+    };
+    const calendarBuilder = new CalendarBuilder(2021, 12);
+    const grid = calendarBuilder.build(loader);
+
+    expect(formatDateKey(grid[0][3].date)).toBe("2021-12-01");
+    expect(formatDateKey(grid[1][0].date)).toBe("2021-12-05");
+  });
+
+  it("returns fresh Date instances for grid cells across builds", () => {
+    const calendarBuilder = new CalendarBuilder(2021, 12);
+    const firstGrid = calendarBuilder.build(mockLoader);
+    const secondGrid = calendarBuilder.build(mockLoader);
+
+    firstGrid[1][0].date.setDate(1);
+
+    expect(formatDateKey(firstGrid[1][1].date)).toBe("2021-12-06");
+    expect(formatDateKey(secondGrid[1][0].date)).toBe("2021-12-05");
+  });
+
+  it("clones Sunday snapshots for each cell", () => {
+    const calendarBuilder = new CalendarBuilder(2021, 12);
+    const grid = calendarBuilder.build(mockLoader);
+
+    grid[1][2].sunday.date.setDate(1);
+
+    expect(formatDateKey(grid[1][3].sunday.date)).toBe("2021-12-05");
+    expect(grid[1][0].sunday).toBeNull();
   });
 });

--- a/lib/KeyLoader.js
+++ b/lib/KeyLoader.js
@@ -1,3 +1,4 @@
+import { toInternalDayjs } from "./date.js";
 import { matchesProperDate } from "./matchesProperDate.js";
 
 /**
@@ -22,16 +23,20 @@ export class KeyLoader {
   /**
    * Load the matching propers for each keyed dataset.
    *
-   * @param {import("luxon").DateTime} date
+   * @param {Date} date
    * @param {number | null} weekOfLectionary
    * @returns {import("./Loader.js").ProperDatasetMap}
    */
   load(date, weekOfLectionary) {
+    const internalDate = toInternalDayjs(date, "KeyLoader.load");
+
     /** @type {import("./Loader.js").ProperDatasetMap} */
     const data = {};
     for (const [key, value] of Object.entries(this.#data)) {
       data[key] = value
-        .filter((proper) => matchesProperDate(proper, date, weekOfLectionary))
+        .filter((proper) =>
+          matchesProperDate(proper, internalDate, weekOfLectionary)
+        )
         .sort((first, second) => {
           if (first.week && !second.week) {
             return -1;

--- a/lib/KeyLoader.test.js
+++ b/lib/KeyLoader.test.js
@@ -1,8 +1,8 @@
-import { DateTime } from "luxon";
-
+import dayjs from "dayjs";
 import lectionary from "../data/lsb-1yr.json";
 import festivals from "../data/lsb-festivals.json";
 import { CalendarBuilder } from "./CalendarBuilder.js";
+import { createLocalDate } from "./date.js";
 import { KeyLoader } from "./KeyLoader.js";
 
 describe("KeyLoader", () => {
@@ -35,7 +35,7 @@ describe("KeyLoader", () => {
 
   it("returns empty arrays for keys with no matching propers", () => {
     const loader = new KeyLoader({ lectionary: [], festivals: [] });
-    const result = loader.load(DateTime.local(2021, 6, 15), 30);
+    const result = loader.load(createLocalDate(2021, 6, 15), 30);
     expect(result.lectionary).toEqual([]);
     expect(result.festivals).toEqual([]);
   });
@@ -50,12 +50,13 @@ describe("KeyLoader", () => {
     };
     const loader = new KeyLoader({ lectionary: [proper] });
     // Week number doesn't matter — feast is matched by month+day
-    const result = loader.load(DateTime.local(2021, 1, 6), 99);
+    const result = loader.load(createLocalDate(2021, 1, 6), 99);
     expect(result.lectionary).toContainEqual(proper);
   });
 
-  it("normalizes Sunday from Luxon weekday 7 to 0 when matching propers", () => {
-    // Propers for Sundays are stored with day=0; Luxon represents Sunday as weekday 7
+  it("matches Sunday propers with weekday 0", () => {
+    // Propers for Sundays are stored with day=0, which matches the loader's
+    // internal Sunday numbering.
     const proper = {
       week: 6,
       month: null,
@@ -64,9 +65,17 @@ describe("KeyLoader", () => {
       text: "Romans 8:1-11",
     };
     const loader = new KeyLoader({ lectionary: [proper] });
-    // Jan 10, 2021 is a Sunday (Luxon weekday 7)
-    const result = loader.load(DateTime.local(2021, 1, 10), 6);
+    // Jan 10, 2021 is a Sunday.
+    const result = loader.load(createLocalDate(2021, 1, 10), 6);
     expect(result.lectionary).toContainEqual(proper);
+  });
+
+  it("rejects Day.js input", () => {
+    const loader = new KeyLoader({ lectionary: [], festivals: [] });
+
+    expect(() => loader.load(dayjs(new Date(2021, 0, 6)), 99)).toThrow(
+      TypeError
+    );
   });
 
   it("sorts week-based propers before month/day propers", () => {
@@ -87,7 +96,7 @@ describe("KeyLoader", () => {
     // Supply month-based first to confirm sort overrides insertion order
     const loader = new KeyLoader({ lectionary: [monthProper, weekProper] });
     // Jan 10, 2021 is a Sunday matching both week=6/day=0 and month=1/day=10
-    const result = loader.load(DateTime.local(2021, 1, 10), 6);
+    const result = loader.load(createLocalDate(2021, 1, 10), 6);
     expect(result.lectionary[0]).toEqual(weekProper);
     expect(result.lectionary[1]).toEqual(monthProper);
   });
@@ -95,7 +104,7 @@ describe("KeyLoader", () => {
   it("keeps fixed-date festivals on their date even when they collide", () => {
     const loader = new KeyLoader({ festivals });
 
-    const result = loader.load(DateTime.local(2027, 3, 25), 21);
+    const result = loader.load(createLocalDate(2027, 3, 25), 21);
     expect(result.festivals).toContainEqual(
       expect.objectContaining({
         type: 0,

--- a/lib/Loader.js
+++ b/lib/Loader.js
@@ -35,7 +35,7 @@
 export default class Loader {
   /**
    * Load specific propers
-   * @param {import("luxon").DateTime} date
+   * @param {Date} date
    * @param {number | null} weekOfLectionary
    * @returns {Proper[] | ProperDatasetMap}
    */

--- a/lib/SimpleLoader.js
+++ b/lib/SimpleLoader.js
@@ -1,3 +1,4 @@
+import { toInternalDayjs } from "./date.js";
 import { matchesProperDate } from "./matchesProperDate.js";
 
 /**
@@ -22,13 +23,14 @@ export class SimpleLoader {
   /**
    * Load the matching propers from the flattened datasets.
    *
-   * @param {import("luxon").DateTime} date
+   * @param {Date} date
    * @param {number | null} weekOfLectionary
    * @returns {import("./Loader.js").Proper[]}
    */
   load(date, weekOfLectionary) {
+    const internalDate = toInternalDayjs(date, "SimpleLoader.load");
     return this.#data.filter((proper) =>
-      matchesProperDate(proper, date, weekOfLectionary)
+      matchesProperDate(proper, internalDate, weekOfLectionary)
     );
   }
 }

--- a/lib/SimpleLoader.test.js
+++ b/lib/SimpleLoader.test.js
@@ -1,8 +1,8 @@
-import { DateTime } from "luxon";
-
+import dayjs from "dayjs";
 import oneyear from "../data/lsb-1yr.json";
 import daily from "../data/lsb-daily.json";
 import { CalendarBuilder } from "./CalendarBuilder.js";
+import { createLocalDate } from "./date.js";
 import { SimpleLoader } from "./SimpleLoader.js";
 
 describe("SimpleLoader", () => {
@@ -32,7 +32,7 @@ describe("SimpleLoader", () => {
 
   it("returns an empty array when no data is provided", () => {
     const loader = new SimpleLoader();
-    const result = loader.load(DateTime.local(2021, 6, 15), 30);
+    const result = loader.load(createLocalDate(2021, 6, 15), 30);
     expect(result).toEqual([]);
   });
 
@@ -45,11 +45,11 @@ describe("SimpleLoader", () => {
       text: "The Nativity of Our Lord",
     };
     const loader = new SimpleLoader([proper]);
-    const result = loader.load(DateTime.local(2021, 12, 25), 99);
+    const result = loader.load(createLocalDate(2021, 12, 25), 99);
     expect(result).toContainEqual(proper);
   });
 
-  it("normalizes Sunday from Luxon weekday 7 to 0 when matching propers", () => {
+  it("matches Sunday propers with weekday 0", () => {
     const proper = {
       week: 6,
       month: null,
@@ -58,8 +58,16 @@ describe("SimpleLoader", () => {
       text: "Romans 8:1-11",
     };
     const loader = new SimpleLoader([proper]);
-    // Jan 10, 2021 is a Sunday (Luxon weekday 7)
-    const result = loader.load(DateTime.local(2021, 1, 10), 6);
+    // Jan 10, 2021 is a Sunday.
+    const result = loader.load(createLocalDate(2021, 1, 10), 6);
     expect(result).toContainEqual(proper);
+  });
+
+  it("rejects Day.js input", () => {
+    const loader = new SimpleLoader();
+
+    expect(() => loader.load(dayjs(new Date(2021, 0, 10)), 6)).toThrow(
+      TypeError
+    );
   });
 });

--- a/lib/Week.js
+++ b/lib/Week.js
@@ -1,4 +1,4 @@
-import { DateTime } from "luxon";
+import { toInternalDayjs, toPublicDate } from "./date.js";
 import { getSunday, getWeekDifference } from "./weekHelpers.js";
 import { Year } from "./Year.js";
 import { YearFactory } from "./YearFactory.js";
@@ -8,31 +8,26 @@ import { YearFactory } from "./YearFactory.js";
  */
 /** @implements {import("./BaseWeek.js").BaseWeek} */
 export class Week {
-  /** @type {import("luxon").DateTime} */
+  /** @type {import("dayjs").Dayjs} */
   #date;
 
   /** @type {Year} */
   #year;
 
   /**
-   * @param {Date | import("luxon").DateTime} date
+   * @param {Date} date
    */
   constructor(date) {
-    // If we're not receiving a luxon DateTime, assume a JSDate and convert
-    if (!(date instanceof DateTime)) {
-      date = DateTime.fromJSDate(date);
-    }
-
-    this.#date = date.startOf("day");
-    this.#year = YearFactory.get(this.#date, Year);
+    this.#date = toInternalDayjs(date, "Week");
+    this.#year = YearFactory.get(this.#date.year(), Year);
   }
 
   /**
    * Find the Sunday closest to the date we're calculating off. If that day is a Sunday, it just returns that date.
-   * @returns {DateTime}
+   * @returns {Date}
    */
   getSunday() {
-    return getSunday(this.#date);
+    return toPublicDate(getSunday(this.#date));
   }
 
   /**
@@ -42,27 +37,48 @@ export class Week {
    * @returns {number | null}
    */
   getWeek() {
-    const advent = this.#year.getAdvent();
-    const epiphany = this.#year.getEpiphany();
-    const epiphanySunday = this.#year.getEpiphanySunday();
-    const transfiguration = this.#year.getTransfiguration();
-    const endOfYear = this.#year.getEndOfYear();
-    const lastSunday = this.#year.getLastSunday();
-    const sunday = this.getSunday();
+    const advent = toInternalDayjs(this.#year.getAdvent(), "Year.getAdvent()");
+    const epiphany = toInternalDayjs(
+      this.#year.getEpiphany(),
+      "Year.getEpiphany()"
+    );
+    const epiphanySunday = toInternalDayjs(
+      this.#year.getEpiphanySunday(),
+      "Year.getEpiphanySunday()"
+    );
+    const transfiguration = toInternalDayjs(
+      this.#year.getTransfiguration(),
+      "Year.getTransfiguration()"
+    );
+    const endOfYear = toInternalDayjs(
+      this.#year.getEndOfYear(),
+      "Year.getEndOfYear()"
+    );
+    const lastSunday = toInternalDayjs(
+      this.#year.getLastSunday(),
+      "Year.getLastSunday()"
+    );
+    const sunday = getSunday(this.#date);
 
     // If Christmas is a Sunday you need to handle this yourself
-    if (sunday.month === 12 && sunday.day === 25) {
+    if (sunday.month() === 11 && sunday.date() === 25) {
       return null;
-    } else if (sunday >= advent) {
+    } else if (sunday.valueOf() >= advent.valueOf()) {
       // After Advent
       return 1 + getWeekDifference(advent, sunday);
-    } else if (sunday >= epiphany && sunday < transfiguration) {
+    } else if (
+      sunday.valueOf() >= epiphany.valueOf() &&
+      sunday.valueOf() < transfiguration.valueOf()
+    ) {
       // After Epiphany, Before Transfiguration
       return 6 + getWeekDifference(epiphanySunday, sunday);
-    } else if (sunday < epiphany) {
+    } else if (sunday.valueOf() < epiphany.valueOf()) {
       // Before Epiphany
       return 6 - getWeekDifference(sunday, epiphanySunday);
-    } else if (sunday >= transfiguration && sunday <= endOfYear) {
+    } else if (
+      sunday.valueOf() >= transfiguration.valueOf() &&
+      sunday.valueOf() <= endOfYear.valueOf()
+    ) {
       // After Transfiguration and before the end of the year (Pentecost)
       return 12 + getWeekDifference(transfiguration, sunday);
     } else {

--- a/lib/Week.test.js
+++ b/lib/Week.test.js
@@ -1,5 +1,7 @@
+import dayjs from "dayjs";
 // This data was generated from the previous PHP version of this library
 import { TEST_DAYS, TEST_SUNDAYS } from "../data/tests.json";
+import { formatDateKey } from "./date.js";
 import Sundays from "./Sundays";
 import { Week } from "./Week.js";
 
@@ -8,6 +10,30 @@ describe("Week edge cases", () => {
     // Dec 25, 2022 is a Sunday — the library explicitly cannot calculate this week.
     // Use MM/DD/YYYY format so the Date is parsed in local time, not UTC.
     expect(new Week(new Date("12/25/2022")).getWeek()).toBeNull();
+  });
+
+  it("normalizes Date inputs to the start of the local day", () => {
+    const sunday = new Week(new Date(2021, 11, 5, 15, 45)).getSunday();
+
+    expect(sunday).toBeInstanceOf(Date);
+    expect(formatDateKey(sunday)).toBe("2021-12-05");
+    expect(sunday.getHours()).toBe(0);
+    expect(sunday.getMinutes()).toBe(0);
+  });
+
+  it("rejects Day.js input", () => {
+    expect(() => new Week(dayjs(new Date(2021, 11, 5, 15, 45)))).toThrow(
+      TypeError
+    );
+  });
+
+  it("returns a fresh Sunday Date each time", () => {
+    const week = new Week(new Date("12/08/2021"));
+    const sunday = week.getSunday();
+
+    sunday.setDate(1);
+
+    expect(formatDateKey(week.getSunday())).toBe("2021-12-05");
   });
 });
 

--- a/lib/Year.js
+++ b/lib/Year.js
@@ -1,5 +1,10 @@
-import { DateTime } from "luxon";
 import { BaseYear } from "./BaseYear.js";
+import {
+  createLocalDate,
+  getLegacyWeekday,
+  toInternalDayjs,
+  toPublicDate,
+} from "./date.js";
 
 /**
  * Calculates important liturgical days for a given calendar year.
@@ -18,43 +23,42 @@ export class Year extends BaseYear {
   }
 
   getAdvent() {
-    const christmas = this.getChristmas();
-    const weekday = christmas.get("weekday");
-    const advent = christmas.minus({ weeks: 3 }).minus({ days: weekday });
-    return advent;
+    const christmas = toInternalDayjs(
+      this.getChristmas(),
+      "Year.getChristmas()"
+    );
+    const weekday = getLegacyWeekday(christmas);
+    return toPublicDate(christmas.subtract(3, "week").subtract(weekday, "day"));
   }
 
   getChristmas() {
-    return DateTime.local(this.#year, 12, 25, 0, 0, 0);
+    return createLocalDate(this.#year, 12, 25);
   }
 
   getEpiphany() {
-    return DateTime.local(this.#year, 1, 6, 0, 0, 0);
+    return createLocalDate(this.#year, 1, 6);
   }
 
   getEpiphanySunday() {
-    const epiphany = this.getEpiphany();
-    return epiphany.weekday === 7
-      ? epiphany
-      : epiphany.minus({ days: epiphany.weekday });
+    const epiphany = toInternalDayjs(this.getEpiphany(), "Year.getEpiphany()");
+    return toPublicDate(
+      epiphany.day() === 0 ? epiphany : epiphany.subtract(epiphany.day(), "day")
+    );
   }
 
   getTransfiguration() {
-    const easter = this.getEaster();
-    const transfiguration = easter.minus({ weeks: 10 });
-    return transfiguration;
+    const easter = toInternalDayjs(this.getEaster(), "Year.getEaster()");
+    return toPublicDate(easter.subtract(10, "week"));
   }
 
   getAshWednesday() {
-    const lent = this.getLent();
-    const ashWednesday = lent.minus({ days: 4 });
-    return ashWednesday;
+    const lent = toInternalDayjs(this.getLent(), "Year.getLent()");
+    return toPublicDate(lent.subtract(4, "day"));
   }
 
   getLent() {
-    const easter = this.getEaster();
-    const lent = easter.minus({ weeks: 6 });
-    return lent;
+    const easter = toInternalDayjs(this.getEaster(), "Year.getEaster()");
+    return toPublicDate(easter.subtract(6, "week"));
   }
 
   getEaster() {
@@ -77,30 +81,26 @@ export class Year extends BaseYear {
     const month = Math.floor(n / 31);
     const day = (n % 31) + 1;
 
-    return DateTime.local(year, month, day, 0, 0, 0);
+    return createLocalDate(year, month, day);
   }
 
   getTrinity() {
-    const easter = this.getEaster();
-    const trinity = easter.plus({ weeks: 6 });
-    return trinity;
+    const easter = toInternalDayjs(this.getEaster(), "Year.getEaster()");
+    return toPublicDate(easter.add(6, "week"));
   }
 
   getPentecost() {
-    const easter = this.getEaster();
-    const pentecost = easter.plus({ weeks: 7 });
-    return pentecost;
+    const easter = toInternalDayjs(this.getEaster(), "Year.getEaster()");
+    return toPublicDate(easter.add(7, "week"));
   }
 
   getLastSunday() {
-    const advent = this.getAdvent();
-    const lastSunday = advent.minus({ weeks: 1 });
-    return lastSunday;
+    const advent = toInternalDayjs(this.getAdvent(), "Year.getAdvent()");
+    return toPublicDate(advent.subtract(1, "week"));
   }
 
   getEndOfYear() {
-    const advent = this.getAdvent();
-    const endOfYear = advent.minus({ weeks: 3 });
-    return endOfYear;
+    const advent = toInternalDayjs(this.getAdvent(), "Year.getAdvent()");
+    return toPublicDate(advent.subtract(3, "week"));
   }
 }

--- a/lib/Year.test.js
+++ b/lib/Year.test.js
@@ -1,124 +1,141 @@
-import { DateTime } from "luxon";
-
+import { formatDateKey } from "./date.js";
 import { Year } from "./Year";
 
 describe("Year", () => {
   it("getAdvent", () => {
     const years = {
-      2017: DateTime.local(2017, 12, 3),
-      2019: DateTime.local(2019, 12, 1),
-      2020: DateTime.local(2020, 11, 29),
+      2017: "2017-12-03",
+      2019: "2019-12-01",
+      2020: "2020-11-29",
     };
 
     Object.keys(years).forEach((year) => {
       const calculator = new Year(year);
-      expect(calculator.getAdvent()).toEqual(years[year]);
+      expect(formatDateKey(calculator.getAdvent())).toBe(years[year]);
     });
   });
 
   it("getChristmas", () => {
-    expect(new Year(2021).getChristmas()).toEqual(DateTime.local(2021, 12, 25));
-    expect(new Year(2022).getChristmas()).toEqual(DateTime.local(2022, 12, 25));
+    expect(formatDateKey(new Year(2021).getChristmas())).toBe("2021-12-25");
+    expect(formatDateKey(new Year(2022).getChristmas())).toBe("2022-12-25");
   });
 
   it("getEpiphany", () => {
-    expect(new Year(2021).getEpiphany()).toEqual(DateTime.local(2021, 1, 6));
-    expect(new Year(2022).getEpiphany()).toEqual(DateTime.local(2022, 1, 6));
+    expect(formatDateKey(new Year(2021).getEpiphany())).toBe("2021-01-06");
+    expect(formatDateKey(new Year(2022).getEpiphany())).toBe("2022-01-06");
   });
 
   it("getEpiphanySunday", () => {
     // Jan 6, 2021 is a Wednesday — rewinds to the prior Sunday, Jan 3
-    expect(new Year(2021).getEpiphanySunday().toISODate()).toEqual(
+    expect(formatDateKey(new Year(2021).getEpiphanySunday())).toEqual(
       "2021-01-03"
     );
     // Jan 6, 2019 is already a Sunday — returns Jan 6 itself
-    expect(new Year(2019).getEpiphanySunday().toISODate()).toEqual(
+    expect(formatDateKey(new Year(2019).getEpiphanySunday())).toEqual(
       "2019-01-06"
     );
   });
 
   it("getEaster", () => {
     const years = {
-      2015: DateTime.local(2015, 4, 5),
-      2016: DateTime.local(2016, 3, 27),
-      2017: DateTime.local(2017, 4, 16),
-      2018: DateTime.local(2018, 4, 1),
-      2019: DateTime.local(2019, 4, 21),
-      2020: DateTime.local(2020, 4, 12),
-      2021: DateTime.local(2021, 4, 4),
-      2022: DateTime.local(2022, 4, 17),
-      2023: DateTime.local(2023, 4, 9),
-      2024: DateTime.local(2024, 3, 31),
-      2025: DateTime.local(2025, 4, 20),
+      2015: "2015-04-05",
+      2016: "2016-03-27",
+      2017: "2017-04-16",
+      2018: "2018-04-01",
+      2019: "2019-04-21",
+      2020: "2020-04-12",
+      2021: "2021-04-04",
+      2022: "2022-04-17",
+      2023: "2023-04-09",
+      2024: "2024-03-31",
+      2025: "2025-04-20",
     };
 
     Object.keys(years).forEach((year) => {
       const calculator = new Year(year);
-      expect(calculator.getEaster()).toEqual(years[year]);
+      expect(formatDateKey(calculator.getEaster())).toBe(years[year]);
     });
   });
 
   it("getLent", () => {
     // Easter minus 6 weeks
-    expect(new Year(2021).getLent()).toEqual(DateTime.local(2021, 2, 21));
-    expect(new Year(2022).getLent()).toEqual(DateTime.local(2022, 3, 6));
+    expect(formatDateKey(new Year(2021).getLent())).toBe("2021-02-21");
+    expect(formatDateKey(new Year(2022).getLent())).toBe("2022-03-06");
   });
 
   it("getAshWednesday", () => {
     // Lent minus 4 days
-    expect(new Year(2021).getAshWednesday()).toEqual(
-      DateTime.local(2021, 2, 17)
-    );
-    expect(new Year(2022).getAshWednesday()).toEqual(
-      DateTime.local(2022, 3, 2)
-    );
+    expect(formatDateKey(new Year(2021).getAshWednesday())).toBe("2021-02-17");
+    expect(formatDateKey(new Year(2022).getAshWednesday())).toBe("2022-03-02");
   });
 
   it("getTransfiguration", () => {
     const years = {
-      2019: DateTime.local(2019, 2, 10),
-      2021: DateTime.local(2021, 1, 24),
-      2022: DateTime.local(2022, 2, 6),
+      2019: "2019-02-10",
+      2021: "2021-01-24",
+      2022: "2022-02-06",
     };
 
     Object.keys(years).forEach((year) => {
       const calculator = new Year(year);
-      expect(calculator.getTransfiguration()).toEqual(years[year]);
+      expect(formatDateKey(calculator.getTransfiguration())).toBe(years[year]);
     });
   });
 
   it("getTrinity", () => {
     // Easter plus 6 weeks
-    expect(new Year(2021).getTrinity()).toEqual(DateTime.local(2021, 5, 16));
-    expect(new Year(2022).getTrinity()).toEqual(DateTime.local(2022, 5, 29));
+    expect(formatDateKey(new Year(2021).getTrinity())).toBe("2021-05-16");
+    expect(formatDateKey(new Year(2022).getTrinity())).toBe("2022-05-29");
   });
 
   it("getPentecost", () => {
     // Easter plus 7 weeks
-    expect(new Year(2021).getPentecost()).toEqual(DateTime.local(2021, 5, 23));
-    expect(new Year(2022).getPentecost()).toEqual(DateTime.local(2022, 6, 5));
+    expect(formatDateKey(new Year(2021).getPentecost())).toBe("2021-05-23");
+    expect(formatDateKey(new Year(2022).getPentecost())).toBe("2022-06-05");
   });
 
   it("getLastSunday", () => {
     // Advent minus 1 week
-    expect(new Year(2021).getLastSunday()).toEqual(
-      DateTime.local(2021, 11, 21)
-    );
-    expect(new Year(2019).getLastSunday()).toEqual(
-      DateTime.local(2019, 11, 24)
-    );
+    expect(formatDateKey(new Year(2021).getLastSunday())).toBe("2021-11-21");
+    expect(formatDateKey(new Year(2019).getLastSunday())).toBe("2019-11-24");
   });
 
   it("getEndOfYear", () => {
     const years = {
-      2019: DateTime.local(2019, 11, 10),
-      2020: DateTime.local(2020, 11, 8),
-      2021: DateTime.local(2021, 11, 7),
+      2019: "2019-11-10",
+      2020: "2020-11-08",
+      2021: "2021-11-07",
     };
 
     Object.keys(years).forEach((year) => {
       const calculator = new Year(year);
-      expect(calculator.getEndOfYear()).toEqual(years[year]);
+      expect(formatDateKey(calculator.getEndOfYear())).toBe(years[year]);
     });
+  });
+
+  it("returns Date instances and fresh copies from its getters", () => {
+    const year = new Year(2025);
+
+    [
+      year.getAdvent(),
+      year.getChristmas(),
+      year.getEpiphany(),
+      year.getEpiphanySunday(),
+      year.getTransfiguration(),
+      year.getAshWednesday(),
+      year.getLent(),
+      year.getEaster(),
+      year.getTrinity(),
+      year.getPentecost(),
+      year.getLastSunday(),
+      year.getEndOfYear(),
+    ].forEach((value) => {
+      expect(value).toBeInstanceOf(Date);
+    });
+
+    const easter = year.getEaster();
+    easter.setFullYear(1900);
+
+    expect(formatDateKey(year.getEaster())).toBe("2025-04-20");
   });
 });

--- a/lib/YearFactory.js
+++ b/lib/YearFactory.js
@@ -1,12 +1,8 @@
-/**
- * Object shape accepted by the factory when the caller passes a Luxon-style
- * date-like value instead of a raw year.
- * @typedef {{ year: number | string }} YearLikeObject
- */
+import { isDayjsValue } from "./date.js";
 
 /**
  * Accepted inputs for deriving a calendar year.
- * @typedef {number | string | Date | YearLikeObject} YearLikeValue
+ * @typedef {number | string | Date} YearLikeValue
  */
 
 /**
@@ -17,8 +13,7 @@
 
 /**
  * Normalize the different "year-like" inputs callers pass into the factory.
- * We accept raw years, JS Dates, and Luxon-style objects with a `year`
- * property so Week/Series can pass their existing date values directly.
+ * We accept raw years and JS Dates at the public boundary.
  *
  * This helper stays file-local so the public factory surface only exposes the
  * behavior consumers are expected to call.
@@ -27,12 +22,14 @@
  * @returns {number}
  */
 function getYear(value) {
-  if (value instanceof Date) {
-    return value.getFullYear();
+  if (isDayjsValue(value)) {
+    throw new TypeError(
+      "YearFactory.get() expects a year number, string, or JavaScript Date"
+    );
   }
 
-  if (value && typeof value === "object" && "year" in value) {
-    return parseInt(value.year, 10);
+  if (value instanceof Date) {
+    return value.getFullYear();
   }
 
   return parseInt(value, 10);

--- a/lib/YearFactory.test.js
+++ b/lib/YearFactory.test.js
@@ -1,8 +1,9 @@
-import { DateTime } from "luxon";
+import dayjs from "dayjs";
 import { describe, expect, it } from "vitest";
 
 import { ThreeYear } from "./3year/Year.js";
 import { BaseYear } from "./BaseYear.js";
+import { formatDateKey } from "./date.js";
 import { Year } from "./Year.js";
 import { YearFactory } from "./YearFactory.js";
 
@@ -26,15 +27,19 @@ describe("YearFactory", () => {
     expect(year).not.toBe(threeYear);
   });
 
-  it("normalizes date-like input by year", () => {
-    const byDateTime = YearFactory.get(DateTime.local(2025, 10, 31), Year);
-    const byDate = YearFactory.get(new Date("10/31/2025"), Year);
-    const byObject = YearFactory.get({ year: "2025" }, Year);
+  it("normalizes Date input by year", () => {
+    const byDate = YearFactory.get(new Date(2025, 9, 31), Year);
     const expectedEaster = new Year(2025).getEaster();
 
-    expect(byDateTime.getEaster()).toEqual(expectedEaster);
-    expect(byDate.getEaster()).toEqual(expectedEaster);
-    expect(byObject.getEaster()).toEqual(expectedEaster);
+    expect(formatDateKey(byDate.getEaster())).toBe(
+      formatDateKey(expectedEaster)
+    );
+  });
+
+  it("rejects Day.js input", () => {
+    expect(() => YearFactory.get(dayjs(new Date(2025, 9, 31)), Year)).toThrow(
+      TypeError
+    );
   });
 
   it("keeps the normalized year private", () => {

--- a/lib/date.js
+++ b/lib/date.js
@@ -1,0 +1,172 @@
+import dayjs from "dayjs";
+
+/** @typedef {import("dayjs").Dayjs} Dayjs */
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * @param {unknown} value
+ * @returns {value is Dayjs}
+ */
+export function isDayjsValue(value) {
+  return dayjs.isDayjs(value);
+}
+
+/**
+ * Validate a public-facing date input.
+ *
+ * @param {unknown} value
+ * @param {string} apiName
+ * @returns {Date}
+ */
+export function assertPublicDate(value, apiName) {
+  if (isDayjsValue(value)) {
+    throw new TypeError(
+      `${apiName} expects a JavaScript Date, not a Day.js value`
+    );
+  }
+
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new TypeError(`${apiName} expects a valid JavaScript Date`);
+  }
+
+  return value;
+}
+
+/**
+ * Clone a JavaScript Date so callers cannot mutate shared state.
+ *
+ * @param {Date} value
+ * @returns {Date}
+ */
+export function cloneDate(value) {
+  return new Date(value.getTime());
+}
+
+/**
+ * Normalize a supported public date input to an internal Day.js instance.
+ *
+ * @param {unknown} value
+ * @param {string} apiName
+ * @returns {Dayjs}
+ */
+export function toInternalDayjs(value, apiName) {
+  return dayjs(cloneDate(assertPublicDate(value, apiName))).startOf("day");
+}
+
+/**
+ * Convert an internal Day.js value to a fresh public JavaScript Date.
+ *
+ * @param {Dayjs} value
+ * @returns {Date}
+ */
+export function toPublicDate(value) {
+  return createLocalDate(value.year(), value.month() + 1, value.date());
+}
+
+/**
+ * Create a local-midnight JavaScript Date from calendar parts.
+ *
+ * @param {number | string} year
+ * @param {number | string} month
+ * @param {number | string} day
+ * @returns {Date}
+ */
+export function createLocalDate(year, month, day) {
+  return new Date(Number(year), Number(month) - 1, Number(day));
+}
+
+/**
+ * Create a local-midnight Day.js value from calendar parts.
+ *
+ * @param {number | string} year
+ * @param {number | string} month
+ * @param {number | string} day
+ * @returns {Dayjs}
+ */
+export function createLocalDayjs(year, month, day) {
+  return dayjs(createLocalDate(year, month, day)).startOf("day");
+}
+
+/**
+ * Format a public Date as YYYY-MM-DD for local-calendar assertions.
+ *
+ * @param {Date} value
+ * @returns {string}
+ */
+export function formatDateKey(value) {
+  const date = assertPublicDate(value, "formatDateKey");
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+/**
+ * Compare two public Dates as local calendar days.
+ *
+ * @param {Date} left
+ * @param {Date} right
+ * @returns {boolean}
+ */
+export function isSameDay(left, right) {
+  const first = assertPublicDate(left, "isSameDay");
+  const second = assertPublicDate(right, "isSameDay");
+
+  return (
+    first.getFullYear() === second.getFullYear() &&
+    first.getMonth() === second.getMonth() &&
+    first.getDate() === second.getDate()
+  );
+}
+
+/**
+ * Return the weekday number using the lectionary convention.
+ *
+ * Day.js already uses Sunday = 0, Monday = 1, ..., Saturday = 6.
+ *
+ * @param {Dayjs} date
+ * @returns {number}
+ */
+export function getLectionaryWeekday(date) {
+  return date.day();
+}
+
+/**
+ * Return the weekday number using the legacy Monday-first convention.
+ *
+ * Some existing church-year calculations are easier to preserve when Sunday is
+ * represented as 7 rather than 0.
+ *
+ * @param {Dayjs} date
+ * @returns {number}
+ */
+export function getLegacyWeekday(date) {
+  const weekday = getLectionaryWeekday(date);
+  return weekday === 0 ? 7 : weekday;
+}
+
+/**
+ * Compare two Day.js values as local calendar dates, ignoring DST shifts.
+ *
+ * @param {Dayjs} first
+ * @param {Dayjs} second
+ * @returns {number}
+ */
+export function getDayDifference(first, second) {
+  const firstUtc = Date.UTC(first.year(), first.month(), first.date());
+  const secondUtc = Date.UTC(second.year(), second.month(), second.date());
+  return (secondUtc - firstUtc) / DAY_IN_MS;
+}
+
+/**
+ * Compare two Day.js values as liturgical week anchors.
+ *
+ * @param {Dayjs} week1
+ * @param {Dayjs} week2
+ * @returns {number}
+ */
+export function getWeekDifference(week1, week2) {
+  return getDayDifference(week1, week2) / 7;
+}

--- a/lib/matchesProperDate.js
+++ b/lib/matchesProperDate.js
@@ -1,3 +1,5 @@
+import { getLectionaryWeekday } from "./date.js";
+
 /**
  * Centralized date-matching rules for propers.
  *
@@ -15,13 +17,14 @@
  * decide which collection is primary while still showing the secondary one.
  */
 /**
- * Normalize Luxon's weekday numbering to the convention used by the lectionary
+ * Normalize Day.js weekday numbering to the convention used by the lectionary
  * JSON files.
  *
- * Luxon:
+ * Day.js:
+ * - Sunday = 0
  * - Monday = 1
  * - ...
- * - Sunday = 7
+ * - Saturday = 6
  *
  * Our data:
  * - Sunday = 0
@@ -32,11 +35,11 @@
  * Week-based propers depend on this mapping, so we keep the translation in one
  * place rather than repeating it inside each loader.
  *
- * @param {DateTime} date
+ * @param {import("dayjs").Dayjs} date
  * @returns {number}
  */
 function getWeekday(date) {
-  return date.weekday === 7 ? 0 : date.weekday;
+  return getLectionaryWeekday(date);
 }
 
 /**
@@ -54,7 +57,7 @@ function getWeekday(date) {
  * them primary.
  *
  * @param {import("./Loader.js").Proper} proper
- * @param {import("luxon").DateTime} date
+ * @param {import("dayjs").Dayjs} date
  * @param {number | null} weekOfLectionary
  * @returns {boolean}
  */
@@ -78,5 +81,5 @@ export function matchesProperDate(proper, date, weekOfLectionary) {
   }
 
   // Fixed-date propers are anchored directly to the stored month/day values.
-  return proper.month === date.month && proper.day === date.day;
+  return proper.month === date.month() + 1 && proper.day === date.date();
 }

--- a/lib/weekHelpers.js
+++ b/lib/weekHelpers.js
@@ -1,22 +1,27 @@
+import {
+  getWeekDifference as getDayjsWeekDifference,
+  getLectionaryWeekday,
+} from "./date.js";
+
 /**
  * Find the Sunday closest to a given date. If that day is already a Sunday, it
  * just returns the original date.
  *
- * @param {import("luxon").DateTime} date
- * @returns {import("luxon").DateTime}
+ * @param {import("dayjs").Dayjs} date
+ * @returns {import("dayjs").Dayjs}
  */
 export function getSunday(date) {
-  return date.weekday === 7 ? date : date.minus({ days: date.weekday });
+  const weekday = getLectionaryWeekday(date);
+  return weekday === 0 ? date : date.subtract(weekday, "day");
 }
 
 /**
  * Find the difference between two liturgical week anchor dates.
  *
- * @param {import("luxon").DateTime} week1
- * @param {import("luxon").DateTime} week2
+ * @param {import("dayjs").Dayjs} week1
+ * @param {import("dayjs").Dayjs} week2
  * @returns {number}
  */
 export function getWeekDifference(week1, week2) {
-  const { weeks } = week2.diff(week1, ["weeks"]).toObject();
-  return weeks;
+  return getDayjsWeekDifference(week1, week2);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@stanlemon/lectionary",
-  "version": "1.1.67",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stanlemon/lectionary",
-      "version": "1.1.67",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "luxon": "^3.7.2",
+        "dayjs": "^1.11.18",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "wouter": "^3.9.0"
@@ -1302,6 +1302,12 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -1814,15 +1820,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/luxon": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stanlemon/lectionary",
-  "version": "1.1.67",
+  "version": "2.0.0",
   "description": "A calculator for the Western Christian church calendar.",
   "keywords": [
     "christian",
@@ -28,7 +28,7 @@
   "type": "module",
   "exports": "./lib/index.js",
   "dependencies": {
-    "luxon": "^3.7.2",
+    "dayjs": "^1.11.18",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "wouter": "^3.9.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1610 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      dayjs:
+        specifier: ^1.11.18
+        version: 1.11.20
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      wouter:
+        specifier: ^3.9.0
+        version: 3.9.0(react@19.2.5)
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.4.12
+        version: 2.4.12
+      '@testing-library/jest-dom':
+        specifier: 6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@vitejs/plugin-react':
+        specifier: 6.0.1
+        version: 6.0.1(vite@8.0.8)
+      '@vitest/coverage-v8':
+        specifier: 4.1.4
+        version: 4.1.4(vitest@4.1.4)
+      jsdom:
+        specifier: 29.0.2
+        version: 29.0.2
+      vite:
+        specifier: 8.0.8
+        version: 8.0.8
+      vitest:
+        specifier: 4.1.4
+        version: 4.1.4(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8)
+
+packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@asamuzakjp/css-color@5.1.10':
+    resolution: {integrity: sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.9':
+    resolution: {integrity: sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@biomejs/biome@2.4.12':
+    resolution: {integrity: sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.12':
+    resolution: {integrity: sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.12':
+    resolution: {integrity: sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.12':
+    resolution: {integrity: sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.4.12':
+    resolution: {integrity: sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.4.12':
+    resolution: {integrity: sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.4.12':
+    resolution: {integrity: sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.4.12':
+    resolution: {integrity: sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.12':
+    resolution: {integrity: sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/wasm-runtime@1.1.3':
+    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.15':
+    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
+
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
+  '@vitest/coverage-v8@4.1.4':
+    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
+    peerDependencies:
+      '@vitest/browser': 4.1.4
+      vitest: 4.1.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lru-cache@11.3.3:
+    resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
+    engines: {node: 20 || >=22}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  regexparam@3.0.0:
+    resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
+    engines: {node: '>=8'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rolldown@1.0.0-rc.15:
+    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  vite@8.0.8:
+    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wouter@3.9.0:
+    resolution: {integrity: sha512-sF/od/PIgqEQBQcrN7a2x3MX6MQE6nW0ygCfy9hQuUkuB28wEZuu/6M5GyqkrrEu9M6jxdkgE12yDFsQMKos4Q==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
+
+  '@asamuzakjp/css-color@5.1.10':
+    dependencies:
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.0.9':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/runtime@7.29.2': {}
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
+
+  '@biomejs/biome@2.4.12':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.12
+      '@biomejs/cli-darwin-x64': 2.4.12
+      '@biomejs/cli-linux-arm64': 2.4.12
+      '@biomejs/cli-linux-arm64-musl': 2.4.12
+      '@biomejs/cli-linux-x64': 2.4.12
+      '@biomejs/cli-linux-x64-musl': 2.4.12
+      '@biomejs/cli-win32-arm64': 2.4.12
+      '@biomejs/cli-win32-x64': 2.4.12
+
+  '@biomejs/cli-darwin-arm64@2.4.12':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.12':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.12':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.12':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.12':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.12':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.12':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.12':
+    optional: true
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@exodus/bytes@1.15.0': {}
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/types@0.124.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.15': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@vitejs/plugin-react@6.0.1(vite@8.0.8)':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.8
+
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.4
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8)
+
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(vite@8.0.8)':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.8
+
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.4': {}
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  dayjs@1.11.20: {}
+
+  decimal.js@10.6.0: {}
+
+  dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
+  entities@6.0.1: {}
+
+  es-module-lexer@2.0.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  has-flag@4.0.0: {}
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
+
+  indent-string@4.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  js-tokens@10.0.0: {}
+
+  js-tokens@4.0.0: {}
+
+  jsdom@29.0.2:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.10
+      '@asamuzakjp/dom-selector': 7.0.9
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.3
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.8
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lru-cache@11.3.3: {}
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
+
+  mdn-data@2.27.1: {}
+
+  min-indent@1.0.1: {}
+
+  mitt@3.0.1: {}
+
+  nanoid@3.3.11: {}
+
+  obug@2.1.1: {}
+
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.9:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  punycode@2.3.1: {}
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react@19.2.5: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  regexparam@3.0.0: {}
+
+  require-from-string@2.0.2: {}
+
+  rolldown@1.0.0-rc.15:
+    dependencies:
+      '@oxc-project/types': 0.124.0
+      '@rolldown/pluginutils': 1.0.0-rc.15
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
+
+  semver@7.7.4: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  symbol-tree@3.2.4: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
+  tslib@2.8.1:
+    optional: true
+
+  undici@7.24.8: {}
+
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
+  vite@8.0.8:
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@4.1.4(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.8)
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      jsdom: 29.0.2
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wouter@3.9.0(react@19.2.5):
+    dependencies:
+      mitt: 3.0.1
+      react: 19.2.5
+      regexparam: 3.0.0
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         version: 3.9.0(react@19.2.5)
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.4.12
-        version: 2.4.12
+        specifier: 2.4.13
+        version: 2.4.13
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
@@ -32,19 +32,19 @@ importers:
         version: 16.3.2(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(vite@8.0.8)
+        version: 6.0.1(vite@8.0.10)
       '@vitest/coverage-v8':
-        specifier: 4.1.4
-        version: 4.1.4(vitest@4.1.4)
+        specifier: 4.1.5
+        version: 4.1.5(vitest@4.1.5)
       jsdom:
         specifier: 29.0.2
         version: 29.0.2
       vite:
-        specifier: 8.0.8
-        version: 8.0.8
+        specifier: 8.0.10
+        version: 8.0.10
       vitest:
-        specifier: 4.1.4
-        version: 4.1.4(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8)
+        specifier: 4.1.5
+        version: 4.1.5(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@8.0.10)
 
 packages:
 
@@ -91,59 +91,59 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@2.4.12':
-    resolution: {integrity: sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==}
+  '@biomejs/biome@2.4.13':
+    resolution: {integrity: sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.12':
-    resolution: {integrity: sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==}
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    resolution: {integrity: sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.12':
-    resolution: {integrity: sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==}
+  '@biomejs/cli-darwin-x64@2.4.13':
+    resolution: {integrity: sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.12':
-    resolution: {integrity: sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==}
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    resolution: {integrity: sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.12':
-    resolution: {integrity: sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==}
+  '@biomejs/cli-linux-arm64@2.4.13':
+    resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.12':
-    resolution: {integrity: sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==}
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.12':
-    resolution: {integrity: sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==}
+  '@biomejs/cli-linux-x64@2.4.13':
+    resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.12':
-    resolution: {integrity: sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==}
+  '@biomejs/cli-win32-arm64@2.4.13':
+    resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.12':
-    resolution: {integrity: sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==}
+  '@biomejs/cli-win32-x64@2.4.13':
+    resolution: {integrity: sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -188,11 +188,11 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@emnapi/core@1.9.2':
-    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -216,112 +216,112 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@napi-rs/wasm-runtime@1.1.3':
-    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@oxc-project/types@0.124.0':
-    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
-    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
-    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
-    engines: {node: '>=14.0.0'}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.15':
-    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
@@ -380,20 +380,20 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  '@vitest/coverage-v8@4.1.4':
-    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
+  '@vitest/coverage-v8@4.1.5':
+    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
     peerDependencies:
-      '@vitest/browser': 4.1.4
-      vitest: 4.1.4
+      '@vitest/browser': 4.1.5
+      vitest: 4.1.5
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.4':
-    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
-  '@vitest/mocker@4.1.4':
-    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -403,20 +403,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.4':
-    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
 
-  '@vitest/runner@4.1.4':
-    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
 
-  '@vitest/snapshot@4.1.4':
-    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
 
-  '@vitest/spy@4.1.4':
-    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
 
-  '@vitest/utils@4.1.4':
-    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -677,8 +677,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.9:
-    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@27.5.1:
@@ -713,8 +713,8 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  rolldown@1.0.0-rc.15:
-    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -796,8 +796,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  vite@8.0.8:
-    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -839,20 +839,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.4:
-    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.4
-      '@vitest/browser-preview': 4.1.4
-      '@vitest/browser-webdriverio': 4.1.4
-      '@vitest/coverage-istanbul': 4.1.4
-      '@vitest/coverage-v8': 4.1.4
-      '@vitest/ui': 4.1.4
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -956,39 +956,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@2.4.12':
+  '@biomejs/biome@2.4.13':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.12
-      '@biomejs/cli-darwin-x64': 2.4.12
-      '@biomejs/cli-linux-arm64': 2.4.12
-      '@biomejs/cli-linux-arm64-musl': 2.4.12
-      '@biomejs/cli-linux-x64': 2.4.12
-      '@biomejs/cli-linux-x64-musl': 2.4.12
-      '@biomejs/cli-win32-arm64': 2.4.12
-      '@biomejs/cli-win32-x64': 2.4.12
+      '@biomejs/cli-darwin-arm64': 2.4.13
+      '@biomejs/cli-darwin-x64': 2.4.13
+      '@biomejs/cli-linux-arm64': 2.4.13
+      '@biomejs/cli-linux-arm64-musl': 2.4.13
+      '@biomejs/cli-linux-x64': 2.4.13
+      '@biomejs/cli-linux-x64-musl': 2.4.13
+      '@biomejs/cli-win32-arm64': 2.4.13
+      '@biomejs/cli-win32-x64': 2.4.13
 
-  '@biomejs/cli-darwin-arm64@2.4.12':
+  '@biomejs/cli-darwin-arm64@2.4.13':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.12':
+  '@biomejs/cli-darwin-x64@2.4.13':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.12':
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.12':
+  '@biomejs/cli-linux-arm64@2.4.13':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.12':
+  '@biomejs/cli-linux-x64-musl@2.4.13':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.12':
+  '@biomejs/cli-linux-x64@2.4.13':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.12':
+  '@biomejs/cli-win32-arm64@2.4.13':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.12':
+  '@biomejs/cli-win32-x64@2.4.13':
     optional: true
 
   '@bramus/specificity@2.4.2':
@@ -1019,13 +1019,13 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@emnapi/core@1.9.2':
+  '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.2':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1046,65 +1046,65 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@oxc-project/types@0.124.0': {}
+  '@oxc-project/types@0.127.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.15': {}
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
@@ -1153,15 +1153,15 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.8)':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10)':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.8
+      vite: 8.0.10
 
-  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
+  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.4
+      '@vitest/utils': 4.1.5
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -1170,46 +1170,46 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8)
+      vitest: 4.1.5(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@8.0.10)
 
-  '@vitest/expect@4.1.4':
+  '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.8)':
+  '@vitest/mocker@4.1.5(vite@8.0.10)':
     dependencies:
-      '@vitest/spy': 4.1.4
+      '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8
+      vite: 8.0.10
 
-  '@vitest/pretty-format@4.1.4':
+  '@vitest/pretty-format@4.1.5':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.4':
+  '@vitest/runner@4.1.5':
     dependencies:
-      '@vitest/utils': 4.1.4
+      '@vitest/utils': 4.1.5
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.4':
+  '@vitest/snapshot@4.1.5':
     dependencies:
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/utils': 4.1.4
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.4': {}
+  '@vitest/spy@4.1.5': {}
 
-  '@vitest/utils@4.1.4':
+  '@vitest/utils@4.1.5':
     dependencies:
-      '@vitest/pretty-format': 4.1.4
+      '@vitest/pretty-format': 4.1.5
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -1426,7 +1426,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.9:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -1458,26 +1458,26 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  rolldown@1.0.0-rc.15:
+  rolldown@1.0.0-rc.17:
     dependencies:
-      '@oxc-project/types': 0.124.0
-      '@rolldown/pluginutils': 1.0.0-rc.15
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   saxes@6.0.0:
     dependencies:
@@ -1539,25 +1539,25 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  vite@8.0.8:
+  vite@8.0.10:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.9
-      rolldown: 1.0.0-rc.15
+      postcss: 8.5.12
+      rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
       fsevents: 2.3.3
 
-  vitest@4.1.4(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8):
+  vitest@4.1.5(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@8.0.10):
     dependencies:
-      '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8)
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/runner': 4.1.4
-      '@vitest/snapshot': 4.1.4
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10)
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -1569,10 +1569,10 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8
+      vite: 8.0.10
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
       jsdom: 29.0.2
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
This pull request migrates the codebase from Luxon to native JavaScript `Date` objects for all public APIs and UI components, and introduces Day.js as an internal-only implementation detail. It standardizes date handling, updates all date formatting and navigation logic to use new utility functions, and ensures weekday and lectionary logic now consistently use Sunday = 0. Documentation and tests are also updated to reflect these changes.

**Date Handling and API Boundary Changes:**

* All public APIs now accept and return native JavaScript `Date` objects at local midnight; Day.js is used internally, and Luxon is fully removed from both the UI and core logic (`app/App.jsx`, `app/Calendar.jsx`, `app/Day.jsx`, `lib/3year/KeyLoader.js`, `lib/3year/KeyLoader.test.js`, `README.md`, `AGENTS.md`) [[1]](diffhunk://#diff-9083eab2552c44780a89fd4861f422ce7d711ceeffa4778cd26de1741e297df9L3) [[2]](diffhunk://#diff-f861c5de2ea963a163c5f6131907c252b5c2fb4c5bd8464964b84848a0b7578fL1-R17) [[3]](diffhunk://#diff-69a963abe636dcbe6e36f4c2e3cecc26b03e096e048b5e75b3653c3e7127cb80L1-R16) [[4]](diffhunk://#diff-2d53352b50f293818b3ef442ff3e86cc176bc8b57035cc4196bc4cc2bd543338R1) [[5]](diffhunk://#diff-23f30b1804bc7db5a1999535dd09d757398958ade37d2f1c7637243add0d2478L1-R7) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-R67) [[7]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L101-R107) [[8]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L128-R136).

* All weekday calculations and lectionary logic now use Sunday = 0, matching Day.js and the lectionary datasets, and tests are updated accordingly (`AGENTS.md`, `lib/3year/KeyLoader.js`) [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L101-R107) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L128-R136) [[3]](diffhunk://#diff-2d53352b50f293818b3ef442ff3e86cc176bc8b57035cc4196bc4cc2bd543338L43-R50).

**UI and Formatting Refactor:**

* All date formatting and navigation in the UI is refactored to use new utility functions in `app/dateFormatting.js`, replacing Luxon methods with native `Date`-based helpers for formatting, navigation, and display (`app/Calendar.jsx`, `app/Day.jsx`, `app/dateFormatting.js`) [[1]](diffhunk://#diff-f861c5de2ea963a163c5f6131907c252b5c2fb4c5bd8464964b84848a0b7578fL226-R240) [[2]](diffhunk://#diff-69a963abe636dcbe6e36f4c2e3cecc26b03e096e048b5e75b3653c3e7127cb80L125-R150) [[3]](diffhunk://#diff-5f71052edb7b50d585d2c108ef4a5c5cf2091cfa9331e34881dc9750efb9e834R1-R56).

**Internal Implementation and Test Updates:**

* Core lectionary and week logic, including `ThreeYearKeyLoader` and its tests, now use native `Date` and Day.js internally, removing Luxon from all calculations and test cases (`lib/3year/KeyLoader.js`, `lib/3year/KeyLoader.test.js`) [[1]](diffhunk://#diff-2d53352b50f293818b3ef442ff3e86cc176bc8b57035cc4196bc4cc2bd543338R1) [[2]](diffhunk://#diff-23f30b1804bc7db5a1999535dd09d757398958ade37d2f1c7637243add0d2478L1-R7).

**Documentation and Dependency Updates:**

* Documentation is updated to clarify the public API contract and date handling expectations, and the supported Node version and Biome schema are bumped (`README.md`, `AGENTS.md`, `biome.json`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-R67) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L101-R107) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L128-R136) [[4]](diffhunk://#diff-2bc8a1f5e9380d5a187a4e90f11b4dd36c3abad6aea44c84be354a4f44cdec55L2-R2).

These changes complete the migration away from Luxon, ensuring consistent, standards-based date handling at all public boundaries and simplifying future maintenance.